### PR TITLE
Fix mounts where destination directory path contains a symlink

### DIFF
--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -112,7 +112,7 @@ func (om *OSMounter) MountSpecial() error {
 }
 
 func (om *OSMounter) BindMount(src, dst string) error {
-	return mounter(src, dst, "", syscall.MS_BIND|syscall.MS_REC, "")
+	return mounter(src, dst, "", uintptr(syscall.MS_BIND|syscall.MS_REC), "")
 }
 
 func (om *OSMounter) Unmount(dir string) error {


### PR DESCRIPTION
We need to resolve symlinks relative to the rootfs, which gets tricky, since we have to do this before chrooting into the rootfs.

The idea is to walk through each path component, and check if any of them is an absolute symlink (pointing outside of the rootfs). Rewrite the path based on the rootfs, and also check that the end result is _still_ inside the rootfs.