### PR TITLE
Chmod rootfs to 0755

### DIFF
--- a/pkg/server/unit.go
+++ b/pkg/server/unit.go
@@ -530,6 +530,7 @@ func (u *Unit) Run(command, env []string, workingdir string, policy api.RestartP
 			glog.Errorf("mountSpecial(): %v", err)
 			return err
 		}
+		defer mounter.UnmountSpecial()
 		u.statusPath = "/status"
 	}
 
@@ -547,11 +548,6 @@ func (u *Unit) Run(command, env []string, workingdir string, policy api.RestartP
 			return err
 		}
 	}
-	err = u.runUnitLoop(command, env, unitin, unitout, uniterr, policy)
 
-	if rootfs != "" {
-		mounter.UnmountSpecial()
-	}
-
-	return err
+	return u.runUnitLoop(command, env, unitin, unitout, uniterr, policy)
 }


### PR DESCRIPTION
This should fix the problem when the application in a unit changes to a non-root UID, and after that it fails to access anything inside its ROOTFS. The issue was, that / inside the chroot was not readable by any non-root account.