### PR TITLE
Bcox share mounts in emptydir

### DIFF
--- a/pkg/server/unit.go
+++ b/pkg/server/unit.go
@@ -612,7 +612,12 @@ func (u *Unit) Run(podname string, command, env []string, workingdir string, pol
 			u.setStateToStartFailure(err)
 			return err
 		}
-		if err := mount.ShareMount("/.oldrootfs", uintptr(syscall.MS_PRIVATE|syscall.MS_REC)); err != nil {
+		// Mark the old root mount sharing as private so we don't
+		// unmount any volumes living in the root that are shared
+		// between namespaces as emptyDirs when we unmount the old
+		// root.
+		shareFlags := uintptr(syscall.MS_PRIVATE | syscall.MS_REC)
+		if err := mount.ShareMount("/.oldrootfs", shareFlags); err != nil {
 			glog.Errorf("ShareMount(%s, private): %v", oldrootfs, err)
 			u.setStateToStartFailure(err)
 			return err


### PR DESCRIPTION
Summary of changes:
1. Bind mount the directory backing the `emptyDir` onto itself and make it a recursive bind, that makes the `emptyDir` a mount point. Being a mount point, it lets us set mount "event" sharing of things mounted inside that mount point. The recursive bind means that anything mounting the `emptyDir` also gets everything already mounted inside the emptyDir's subtree. 
2. When we mount the `emptyDir` inside a unit, mark it as shared so that mount "events" propagate to the other namespaces (the original root and other units)
3. When setting up the unit's filesystem namespace, we've always called `pivot_root` and then unmount the old filesystem.  That'll cause us to recursively unmount anything mounted in the emptyDirs mounted in the root filesystem.  Those unmount "events" propogate to all the other units as well and cause everything in those emptyDirs to be unmounted.  We prevent that by changing the sharing of the `.oldrootfs` filesystem to private inside the new namespace.  That prevents any emptyDir shared mounts from getting unmounted in other namespaces.

There's an open question for how this works with a memory-backed emptyDir.  I haven't looked into that yet.  I'm unsure how much time to spend on that.  Feel free to comment on that.

I have't thought about security implications of any of this.  I really don't think that's much of an issue since we don't care much about privileges on the VMs.