### PR TITLE
bump up ulimits for itzo

### DIFF
--- a/scripts/elotl/configure.sh
+++ b/scripts/elotl/configure.sh
@@ -53,6 +53,7 @@ command_user="root"
 pidfile="/run/\$RC_SVCNAME/\$RC_SVCNAME.pid"
 start_stop_daemon_args=""
 command_background="yes"
+rc_ulimit='-n 1024000 -p 30112'
 
 depend() {
         need net localmount
@@ -281,6 +282,11 @@ step 'Enable vsyscall emulation'
 sed -Ei -e "s|^[# ]*(default_kernel_opts)=.*|\1=\"vsyscall=emulate\"|" \
 	/etc/update-extlinux.conf
 update-extlinux --warn-only 2>&1 | grep -Fv 'extlinux: cannot open device /dev' >&2
+
+step 'Sysctl tweaks'
+cat > /etc/sysctl.d/local.conf <<-EOF
+fs.file-max = 1024000
+EOF
 
 step 'Enable services'
 rc-update add acpid default


### PR DESCRIPTION
Bump up ulimits for files and processes (threads).

I chose the file number to be sufficiently high that it'll likely support 500,000 connections through nginx/haproxy.  The max number or processes was 1) high and 2) equal to what ubuntu sets.