### PR TITLE
Have Milpa push pod IP

### DIFF
--- a/pkg/api/internal.go
+++ b/pkg/api/internal.go
@@ -6,6 +6,7 @@ type PodParameters struct {
 	Spec        PodSpec                        `json:"spec"`
 	PodName     string
 	NodeName    string
+	PodIP       string
 }
 
 type RegistryCredentials struct {


### PR DESCRIPTION
So we have this problem on Azure, where the metadata service fails to show the secondary IP address for a while after the instance boots up (eventually the secondary IP address will show IP).

I refactored itzo to accept the pod IP as a parameter from milpa, and also return the actual IP address used by the pod (which depends on whether host networking is requested for the pod).

This assumes Milpa will set the pod IP in pod update requests; though, if it is not the case, itzo will revert to the old behavior, and use the primary IP address for both the pod and the host system. Thus we won't break interoperability with older Milpa versions.