### PR TITLE
Ability to build and store GCE machine images

### DIFF
--- a/pkg/server/pod_controller.go
+++ b/pkg/server/pod_controller.go
@@ -389,7 +389,7 @@ func (pc *PodController) saveUnitConfig(unit *api.Unit, podSecurityContext *api.
 		LivenessProbe:            translateProbePorts(unit, unit.LivenessProbe),
 		TerminationMessagePolicy: unit.TerminationMessagePolicy,
 		TerminationMessagePath:   unit.TerminationMessagePath,
-		PodIP: pc.podIP,
+		PodIP:                    pc.podIP,
 	}
 	if podSecurityContext != nil {
 		unitConfig.PodSecurityContext = *podSecurityContext

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -41,7 +41,9 @@ while [[ -n "$1" ]]; do
         "-c"|"--cloud")
             shift
             CLOUD_PROVIDER="$1"
-            if [[ "$CLOUD_PROVIDER" != "aws" ]] && [[ "$CLOUD_PROVIDER" != "azure" ]]; then
+            if [[ "$CLOUD_PROVIDER" != "aws" ]] && 
+                [[ "$CLOUD_PROVIDER" != "azure" ]] &&
+                [[ "$CLOUD_PROVIDER" != "gce" ]]; then
                 echo "Error, invalid cloud provider specified."
                 exit 1
             fi
@@ -122,6 +124,16 @@ if [[ "$CLOUD_PROVIDER" == "azure" ]] && [[ "$NO_IMAGE" = false ]]; then
     echo "OK"
 fi
 
+if [[ "$CLOUD_PROVIDER" == "gce" ]] && [[ "$NO_IMAGE" = false ]]; then
+    REQUIRED_PROGRAMS="$REQUIRED_PROGRAMS gsutil gcloud jq"
+    if [[ ! -d "$HOME/.config/gcloud" ]]; then
+        echo "Error: please set up gcloud with a service account"
+        echo "e.g. gcloud auth activate-service-account --key-file PATH_TO_KEYFILE.json"
+        exit 1
+    fi
+    echo "OK"
+fi
+
 REQUIRED_PROGRAMS="qemu-img qemu-nbd"
 echo "Checking if required programs are installed."
 for prg in $REQUIRED_PROGRAMS; do
@@ -178,6 +190,8 @@ if [[ "$CLOUD_PROVIDER" == "aws" ]]; then
     python ec2-make-ami.py --input "$IMAGE_ABSPATH" --name $IMAGE_NAME
 elif [[ "$CLOUD_PROVIDER" == "azure" ]]; then
     ./azure-make-image.sh "$IMAGE_ABSPATH" $IMAGE_NAME
+elif [[ "$CLOUD_PROVIDER" == "gce" ]]; then
+    ./gce-make-image.sh "$IMAGE_ABSPATH" "$IMAGE_NAME"
 else
     echo "Unknown cloud provider: $CLOUD_PROVIDER"
 fi

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -134,7 +134,7 @@ if [[ "$CLOUD_PROVIDER" == "gce" ]] && [[ "$NO_IMAGE" = false ]]; then
     echo "OK"
 fi
 
-REQUIRED_PROGRAMS="qemu-img qemu-nbd"
+REQUIRED_PROGRAMS="$REQUIRED_PROGRAMS qemu-img qemu-nbd"
 echo "Checking if required programs are installed."
 for prg in $REQUIRED_PROGRAMS; do
     found=true

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -166,6 +166,10 @@ echo "Creating image of size $IMAGE_SIZE at $IMAGE_ABSPATH."
 
 pushd alpine-make-vm-image > /dev/null
 
+# checkout head to use 3.11 repos
+git checkout 581202213db0643b1b9c7d97c68ccdf6b74f0c97
+git clean -fdx
+
 #
 # You can test the image locally via something like this:
 #

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -166,7 +166,6 @@ echo "Creating image of size $IMAGE_SIZE at $IMAGE_ABSPATH."
 
 pushd alpine-make-vm-image > /dev/null
 
-git checkout ea6dcfe63580dc3c4aa14c7bb362c9bb67f23e01
 git clean -fdx
 
 #

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -166,8 +166,6 @@ echo "Creating image of size $IMAGE_SIZE at $IMAGE_ABSPATH."
 
 pushd alpine-make-vm-image > /dev/null
 
-git clean -fdx
-
 #
 # You can test the image locally via something like this:
 #

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -168,6 +168,7 @@ pushd alpine-make-vm-image > /dev/null
 
 # checkout head to use 3.11 repos
 git checkout 581202213db0643b1b9c7d97c68ccdf6b74f0c97
+
 git clean -fdx
 
 #

--- a/scripts/elotl/packages-gce
+++ b/scripts/elotl/packages-gce
@@ -1,0 +1,15 @@
+chrony
+less
+logrotate
+openssh
+ssmtp
+sudo
+e2fsprogs-extra
+ca-certificates
+util-linux
+rng-tools
+haveged
+hvtools
+iptables
+ipset
+iproute2

--- a/scripts/elotl/repositories
+++ b/scripts/elotl/repositories
@@ -1,2 +1,2 @@
-https://nl.alpinelinux.org/alpine/v3.9/main
-https://nl.alpinelinux.org/alpine/v3.9/community
+https://nl.alpinelinux.org/alpine/v3.11/main
+https://nl.alpinelinux.org/alpine/v3.11/community

--- a/scripts/gce-make-image.sh
+++ b/scripts/gce-make-image.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Copyright 2020 Elotl Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+
+# Args:
+if [ $# -lt 2 ]; then
+    script_name=`basename $0`
+    echo "Usage: $script_name <input_image_path> <cloud_image_name>"
+    exit 1
+fi
+
+IMAGE_ABSPATH="$1"
+IMAGE_NAME="$2"
+
+# Constants
+readonly STORAGE_CONTAINER="itzodisks"
+readonly GCE_IMAGE_NAME="disk.raw"
+readonly GCE_TAR_NAME="$IMAGE_NAME.tar.gz"
+
+echo "building from $IMAGE_ABSPATH into $IMAGE_NAME"
+
+echo "converting qcow2 to raw"
+qemu-img convert -f qcow2 -O raw "$IMAGE_ABSPATH" "$GCE_IMAGE_NAME"
+echo "creating compressed tar archive"
+sudo tar --format=oldgnu -Sczf "$GCE_TAR_NAME" "$GCE_IMAGE_NAME"
+echo "creating bucket $STORAGE_CONTAINER if it does not exist"
+gsutil mb gs://"$STORAGE_CONTAINER" || echo "bucket exists"
+echo "copying compressed image to bucket: $STORAGE_CONTAINER"
+gsutil cp "$GCE_TAR_NAME" gs://"$STORAGE_CONTAINER"
+echo "creating image for GCE compute images"
+gcloud compute images create "$IMAGE_NAME" --source-uri gs://"$STORAGE_CONTAINER/$GCE_TAR_NAME"
+


### PR DESCRIPTION
Changes:
- Updating build-image.sh to allow for gce builds and pushes to gce storage. 
- Script to convert the qcow2 image into raw format, compress it, store in gcp, and create a machine image. 
- Added `scripts/elotl/packages-gce` for host packages
- Updated the repositories file to use alpine 3.11 repos
