### PR TITLE
Refactor image pulling and extraction

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -320,6 +320,14 @@
   revision = "7109fa855b0ff1ebef7fbd2f6aa613e8db7cfbc0"
 
 [[projects]]
+  digest = "1:2199118a5de91125b472c6a71ecd81b636d7ce252f64087e57f1ba5830f1451a"
+  name = "golang.org/x/mod"
+  packages = ["semver"]
+  pruneopts = "UT"
+  revision = "ed3ec21bb8e252814c380df79a80f366440ddb2d"
+  version = "v0.2.0"
+
+[[projects]]
   branch = "master"
   digest = "1:d1209fa9ed40a3a24de8498a9bead59eb3333f16a73fa23ba1fc6677a3cfc9d7"
   name = "golang.org/x/net"
@@ -452,6 +460,7 @@
     "github.com/syndtr/gocapability/capability",
     "github.com/vishvananda/netlink",
     "github.com/vishvananda/netns",
+    "golang.org/x/mod/semver",
     "golang.org/x/net/context",
     "golang.org/x/sys/unix",
     "k8s.io/apimachinery/pkg/util/intstr",

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -1,0 +1,7 @@
+package image
+
+type ImageClient interface {
+	Login(server, username, password string) error
+	Pull(server, image string) error
+	Unpack(image, dest string) error
+}

--- a/pkg/image/img.go
+++ b/pkg/image/img.go
@@ -1,0 +1,64 @@
+package image
+
+import (
+	"net/url"
+
+	"github.com/elotl/itzo/pkg/util"
+)
+
+// This image client is non-functional right now, since it can't export image
+// configs. It's only here for reference.
+
+const (
+	ImgMaxRetries     = 3
+	ImgOutputLimit    = 4096
+	ImgExe            = "img"
+	ImgMinimumVersion = "v0.5.7"
+	ImgURL            = "https://github.com/genuinetools/img/releases/download/v0.5.7/img-linux-amd64"
+)
+
+type Img struct {
+	stateDir string
+	exe      string
+}
+
+func NewImg(stateDir, imgExe string) *Img {
+	return &Img{
+		stateDir: stateDir,
+		exe:      ImgExe,
+	}
+}
+
+func (i *Img) Login(server, username, password string) error {
+	return i.run(
+		"login", "--username", username, "--password", password, server)
+}
+
+func (i *Img) Pull(server, image string) error {
+	if server != "" {
+		host := server
+		u, err := url.Parse(server)
+		if err == nil {
+			host = u.Host
+		}
+		image = host + "/" + image
+	}
+	return i.run(
+		"pull", "--state", i.stateDir, image)
+}
+
+func (i *Img) Unpack(image, dest, configPath string) error {
+	return i.run(
+		"unpack", "--state", i.stateDir, "--output", dest, image)
+}
+
+func (i *Img) run(args ...string) error {
+	exe, err := util.EnsureProg(i.exe, ImgURL, ImgMinimumVersion, "version")
+	if err != nil {
+		return err
+	}
+	if exe != i.exe {
+		i.exe = exe
+	}
+	return util.RunProg(exe, ImgOutputLimit, ImgMaxRetries, args...)
+}

--- a/pkg/image/tosi.go
+++ b/pkg/image/tosi.go
@@ -1,0 +1,77 @@
+package image
+
+import (
+	"fmt"
+
+	"github.com/elotl/itzo/pkg/util"
+)
+
+const (
+	TosiMaxRetries     = 3
+	TosiOutputLimit    = 4096
+	TosiExe            = "tosi"
+	TosiMinimumVersion = "v0.0.3"
+	TosiURL            = "https://github.com/elotl/tosi/releases/download/v0.0.3/tosi-amd64"
+)
+
+type Tosi struct {
+	server   string
+	username string
+	password string
+	image    string
+	exe      string
+}
+
+func NewTosi() *Tosi {
+	return &Tosi{
+		exe: TosiExe,
+	}
+}
+
+func (t *Tosi) Login(server, username, password string) error {
+	t.server = server
+	t.username = username
+	t.password = password
+	return nil
+}
+
+func (t *Tosi) Pull(server, image string) error {
+	t.server = server
+	t.image = image
+	return nil
+}
+
+func (t *Tosi) Unpack(image, dest, configPath string) error {
+	if image != t.image {
+		return fmt.Errorf("image mismatch %q != %q", t.image, image)
+	}
+	return t.run(t.server, t.image, dest, configPath, t.username, t.password)
+}
+
+func (t *Tosi) run(server, image, dest, configPath, username, password string) error {
+	tp, err := util.EnsureProg(t.exe, TosiURL, TosiMinimumVersion, "-version")
+	if err != nil {
+		return err
+	}
+	if t.exe != tp {
+		t.exe = tp
+	}
+	args := []string{
+		"-image",
+		image,
+		"-mount",
+		dest,
+		"-saveconfig",
+		configPath,
+	}
+	if username != "" {
+		args = append(args, []string{"-username", username}...)
+	}
+	if password != "" {
+		args = append(args, []string{"-password", password}...)
+	}
+	if server != "" {
+		args = append(args, []string{"-url", server}...)
+	}
+	return util.RunProg(tp, TosiOutputLimit, TosiMaxRetries, args...)
+}

--- a/pkg/net/ns.go
+++ b/pkg/net/ns.go
@@ -74,7 +74,7 @@ func (n *OSNetNamespacer) Create() error {
 func withNetNamespace(ns netns.NsHandle, cb func() error) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
-	oldNs, err := netns.Get()
+	oldNs, err := netns.GetFromPid(os.Getpid())
 	if err != nil {
 		return err
 	}

--- a/pkg/net/ns.go
+++ b/pkg/net/ns.go
@@ -76,12 +76,12 @@ func withNetNamespace(ns netns.NsHandle, cb func() error) error {
 	defer runtime.UnlockOSThread()
 	oldNs, err := netns.GetFromPid(os.Getpid())
 	if err != nil {
-		return err
+		return fmt.Errorf("getting old net NS: %v", err)
 	}
 	defer oldNs.Close()
 	err = netns.Set(ns)
 	if err != nil {
-		return err
+		return fmt.Errorf("setting new net NS: %v", err)
 	}
 	defer netns.Set(oldNs)
 	return cb()
@@ -91,7 +91,7 @@ func withNetNamespace(ns netns.NsHandle, cb func() error) error {
 func (n *OSNetNamespacer) WithNetNamespace(cb func() error) error {
 	ns, err := netns.GetFromName(n.NSName)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting net NS from %s: %v", n.NSName, err)
 	}
 	defer ns.Close()
 	return withNetNamespace(ns, cb)

--- a/pkg/server/pipe_test.go
+++ b/pkg/server/pipe_test.go
@@ -30,7 +30,6 @@ import (
 func TestCheckName(t *testing.T) {
 	checkName(PIPE_UNIT_STDOUT)
 	checkName(PIPE_UNIT_STDERR)
-	checkName(PIPE_HELPER_OUT)
 }
 
 func TestReadWrite(t *testing.T) {
@@ -47,7 +46,7 @@ func TestReadWrite(t *testing.T) {
 			defer wg.Done()
 			buf.Write([]byte(line))
 		})
-		w, err := lp.OpenWriter(name, false)
+		w, err := lp.OpenWriter(name)
 		assert.Nil(t, err)
 		defer w.Close()
 		output := []byte(fmt.Sprintf("Hello %s!\n", name))
@@ -68,7 +67,7 @@ func TestWriterClose(t *testing.T) {
 	})
 	for _, name := range UNIT_PIPES {
 		assert.Nil(t, lp.Pipes[name])
-		w, err := lp.OpenWriter(name, false)
+		w, err := lp.OpenWriter(name)
 		assert.Nil(t, err)
 		assert.NotNil(t, w)
 		assert.NotNil(t, lp.Pipes[name])
@@ -104,7 +103,7 @@ func TestRemoveActive(t *testing.T) {
 	pipes := make(map[string]*os.File)
 	for _, name := range UNIT_PIPES {
 		assert.Nil(t, lp.Pipes[name])
-		w, err := lp.OpenWriter(name, false)
+		w, err := lp.OpenWriter(name)
 		assert.Nil(t, err)
 		assert.NotNil(t, w)
 		pipes[name] = w

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -741,7 +741,7 @@ func TestAttach(t *testing.T) {
 	unitin, err := u.openStdinReader()
 	assert.NoError(t, err)
 	lp := u.LogPipe
-	unitout, err := lp.OpenWriter(PIPE_UNIT_STDOUT, false)
+	unitout, err := lp.OpenWriter(PIPE_UNIT_STDOUT)
 	defer unitout.Close()
 
 	// start a unit that we can get stdin and stdout from

--- a/pkg/server/unit.go
+++ b/pkg/server/unit.go
@@ -903,21 +903,14 @@ func (u *Unit) Run(podname, hostname string, command []string, workingdir string
 	// Open log pipes _before_ chrooting, since the named pipes are outside of
 	// the rootfs.
 	lp := u.LogPipe
-	helperout, err := lp.OpenWriter(PIPE_HELPER_OUT, true)
-	if err != nil {
-		lp.Remove()
-		u.setStateToStartFailure(err)
-		return err
-	}
-	defer helperout.Close()
-	unitout, err := lp.OpenWriter(PIPE_UNIT_STDOUT, false)
+	unitout, err := lp.OpenWriter(PIPE_UNIT_STDOUT)
 	if err != nil {
 		lp.Remove()
 		u.setStateToStartFailure(err)
 		return err
 	}
 	defer unitout.Close()
-	uniterr, err := lp.OpenWriter(PIPE_UNIT_STDERR, false)
+	uniterr, err := lp.OpenWriter(PIPE_UNIT_STDERR)
 	if err != nil {
 		lp.Remove()
 		u.setStateToStartFailure(err)

--- a/pkg/server/unit_manager.go
+++ b/pkg/server/unit_manager.go
@@ -196,6 +196,12 @@ func (um *UnitManager) StartUnit(podname, hostname, unitname, workingdir, netns 
 			um.rootDir, err)
 	}
 	if !isUnitRootfsMissing {
+		// If the parent mount of rootfs is shared, pivot_root will fail with
+		// EINVAL. Adding CLONE_NEWNS to Unshareflags takes care of this, but
+		// it also does it recursively (MS_REC), which might interfere if the
+		// pod wants to share mounts under a rootfs subtree. We will make the
+		// parent mount private right before calling pivot_root instead. Also
+		// see https://go-review.googlesource.com/c/go/+/38471
 		cmd.SysProcAttr = &syscall.SysProcAttr{
 			Cloneflags: syscall.CLONE_NEWUTS | syscall.CLONE_NEWPID | syscall.CLONE_NEWNS,
 		}

--- a/pkg/server/unit_manager.go
+++ b/pkg/server/unit_manager.go
@@ -175,6 +175,8 @@ func (um *UnitManager) StartUnit(podname, hostname, unitname, workingdir, netns 
 		netns,
 	}
 	cmd := exec.Command("/proc/self/exe", cmdline...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 
 	env := unit.GetEnv() // Default environment from image config.
 	for _, e := range appenv {
@@ -240,8 +242,5 @@ func (um *UnitManager) CaptureLogs(name string, unit *Unit) {
 	})
 	lp.StartReader(PIPE_UNIT_STDERR, func(line string) {
 		um.logbuf.Get(name).Write(logbuf.StderrLogSource, line)
-	})
-	lp.StartReader(PIPE_HELPER_OUT, func(line string) {
-		um.logbuf.Get(name).Write(logbuf.HelperLogSource, line)
 	})
 }

--- a/pkg/server/unit_manager.go
+++ b/pkg/server/unit_manager.go
@@ -40,11 +40,13 @@ const (
 func StartUnit(rootdir, podname, hostname, unitname, workingdir, netns string, command []string, policy api.RestartPolicy) error {
 	unit, err := OpenUnit(rootdir, unitname)
 	if err != nil {
+		glog.Errorf("opening unit %s: %v", unitname, err)
 		return err
 	}
 	mounter := mount.NewOSMounter(rootdir)
 	nser := net.NewNoopNetNamespacer()
 	if netns != "" && !api.IsHostNetwork(&unit.unitConfig.PodSecurityContext) {
+		glog.Infof("%s/%s will run in namespace %s", podname, unitname, netns)
 		nser = net.NewOSNetNamespacer(netns)
 	}
 	glog.Infof("Starting %v for %s rootdir %s env %v workingdir %s policy %v",

--- a/pkg/server/util.go
+++ b/pkg/server/util.go
@@ -29,7 +29,6 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/elotl/itzo/pkg/util"
@@ -218,11 +217,6 @@ func runNetworkAgent(IP, nodeName string) *exec.Cmd {
 		"--run-router=false",
 		"--v=2",
 	)
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Credential: &syscall.Credential{
-			Gid: uint32(util.ItzoGroupID),
-		},
-	}
 	cmd.Stdout = logfile
 	cmd.Stderr = logfile
 	err = cmd.Start()

--- a/pkg/server/util.go
+++ b/pkg/server/util.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net/http"
 	"os"
 	"os/exec"
 	"path"
@@ -38,13 +37,9 @@ import (
 )
 
 var (
-	TOSI_MAX_RETRIES               = 3
 	MaxBufferSize            int64 = 1024 * 1024 * 10 // 10MB
-	TOSI_PRG                       = "tosi"
-	TOSI_OUTPUT_LIMIT              = 4096
 	NVIDIA_CONTAINER_CLI_PRG       = "nvidia-container-cli"
 	NVIDIA_SMI_PRG                 = "nvidia-smi"
-	ITZO_GROUP_ID                  = 600 // Group is created when the image is created
 	NETWORK_AGENT                  = "kube-router"
 )
 
@@ -163,75 +158,6 @@ func ensureFileExists(name string) error {
 	return nil
 }
 
-func downloadTosi(tosipath string) error {
-	resp, err := http.Get("http://tosi-download.s3.amazonaws.com/tosi")
-	if err != nil {
-		return fmt.Errorf("Error creating get request for tosi: %+v", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
-		return fmt.Errorf("Error downloading tosi: got S3 statuscode %d",
-			resp.StatusCode)
-	}
-	f, err := os.OpenFile(tosipath, os.O_WRONLY|os.O_CREATE, 0755)
-	if err != nil {
-		return fmt.Errorf("Error opening tosi for writing after download: %+v",
-			err)
-	}
-	defer f.Close()
-	_, err = io.Copy(f, resp.Body)
-	if err != nil {
-		return fmt.Errorf("Error writing tosi to filesystem: %+v", err)
-	}
-	return nil
-}
-
-func runTosi(tp string, args ...string) error {
-	glog.Infof("Running tosi %s with args %v", tp, args)
-	n := 0
-	start := time.Now()
-	backoff := 1 * time.Second
-	for {
-		n++
-		var stderr bytes.Buffer
-		cmd := exec.Command(tp, args...)
-		cmd.SysProcAttr = &syscall.SysProcAttr{}
-		cmd.SysProcAttr.Credential = &syscall.Credential{
-			Gid: uint32(ITZO_GROUP_ID),
-		}
-
-		cmd.Stderr = &stderr
-		err := cmd.Run()
-		if err == nil {
-			glog.Infof("Image download succeeded after %d attempt(s), %v",
-				n, time.Now().Sub(start))
-			return err
-		}
-		freebs, availbs, serr := util.GetNumberOfFreeAndAvailableBlocks("/")
-		if serr == nil && (freebs < 5 || availbs < 5) {
-			err = fmt.Errorf("Low disk space while getting image, "+
-				"free blocks: %d available blocks: %d",
-				freebs, availbs)
-			glog.Errorf("Image download problem: %v", err)
-			return err
-		}
-		output := stderr.String()
-		if len(output) > TOSI_OUTPUT_LIMIT {
-			output = output[len(output)-TOSI_OUTPUT_LIMIT:]
-		}
-		err = fmt.Errorf(
-			"Error getting image after %d attempt(s): %+v, tosi output:\n%s",
-			n, err, output)
-		glog.Errorf("Image download problem: %v", err)
-		if n >= TOSI_MAX_RETRIES {
-			return err
-		}
-		glog.Infof("Retrying image download in %v", backoff)
-		time.Sleep(backoff)
-		backoff = backoff * 2
-	}
-}
-
 func runNetworkAgent(IP, nodeName string) *exec.Cmd {
 	pth, err := exec.LookPath(NETWORK_AGENT)
 	if err != nil {
@@ -291,7 +217,7 @@ func runNetworkAgent(IP, nodeName string) *exec.Cmd {
 	)
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Credential: &syscall.Credential{
-			Gid: uint32(ITZO_GROUP_ID),
+			Gid: uint32(util.ItzoGroupID),
 		},
 	}
 	cmd.Stdout = logfile

--- a/pkg/server/util.go
+++ b/pkg/server/util.go
@@ -37,10 +37,12 @@ import (
 )
 
 var (
+	KubeRouterProg                 = "kube-router"
+	KubeRouterURL                  = "https://milpa-builds.s3.amazonaws.com/kube-router"
+	KubeRouterMinimumVersion       = "v0.3.1"
 	MaxBufferSize            int64 = 1024 * 1024 * 10 // 10MB
 	NVIDIA_CONTAINER_CLI_PRG       = "nvidia-container-cli"
 	NVIDIA_SMI_PRG                 = "nvidia-smi"
-	NETWORK_AGENT                  = "kube-router"
 )
 
 func copyFile(src, dst string) error {
@@ -159,9 +161,10 @@ func ensureFileExists(name string) error {
 }
 
 func runNetworkAgent(IP, nodeName string) *exec.Cmd {
-	pth, err := exec.LookPath(NETWORK_AGENT)
+	pth, err := util.EnsureProg(
+		KubeRouterProg, KubeRouterURL, KubeRouterMinimumVersion, "--version")
 	if err != nil {
-		glog.Errorf("failed to look up path of %q: %v", NETWORK_AGENT, err)
+		glog.Errorf("failed to look up path of %q: %v", KubeRouterProg, err)
 		return nil
 	}
 	// Kubeconfig has been deployed as a package. Find the actual config file

--- a/pkg/util/image.go
+++ b/pkg/util/image.go
@@ -17,34 +17,23 @@ limitations under the License.
 package util
 
 import (
-	"fmt"
 	"strings"
 )
 
-// Most registry URLs don't have a leading scheme (e.g. http://).
-// This means that we can't use url.Parse to find the host name from
-// the image's path.  We'll use some heuristics to get the server and
-// image path.
+// Parse the image spec and extract the registry server and the repo name.
+// Example image specs:
+//   ECS: ACCOUNT.dkr.ecr.REGION.amazonaws.com/imagename:tag
+//   Docker Hub: imagename:tag or owner/imagename:tag
 func ParseImageSpec(image string) (string, string, error) {
 	server := ""
-	imageRepo := image
+	repo := image
 	var err error
 	parts := strings.Split(image, "/")
-	// ECS: ACCOUNT.dkr.ecr.REGION.amazonaws.com/imagename:tag
 	if len(parts) == 1 {
-		imageRepo = strings.Join([]string{"library", parts[0]}, "/")
-	} else if len(parts) >= 2 && strings.HasSuffix(parts[0], "amazonaws.com") {
+		repo = strings.Join([]string{"library", parts[0]}, "/")
+	} else if strings.Contains(parts[0], ".") {
 		server = parts[0]
-		imageRepo = strings.Join(parts[1:], "/")
-	} else if len(parts) == 2 {
-		//assumes docker registry: user/registry:tag
-		server = ""
-	} else if len(parts) >= 3 {
-		// everything else: server.tld/user/registry:tag
-		server = parts[0]
-		imageRepo = strings.Join(parts[1:], "/")
-	} else {
-		err = fmt.Errorf("Unknown image registry format")
+		repo = strings.Join(parts[1:], "/")
 	}
-	return server, imageRepo, err
+	return server, repo, err
 }

--- a/pkg/util/prog.go
+++ b/pkg/util/prog.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math"
+	"math/rand"
 	"net/http"
 	"os"
 	"os/exec"
@@ -111,7 +113,7 @@ func RunProg(prog string, outputLimit, maxRetries int, args ...string) error {
 	glog.Infof("running %s with args %v", prog, args)
 	n := 0
 	start := time.Now()
-	backoff := 1 * time.Second
+	backoff := 3
 	for {
 		n++
 		var stderr bytes.Buffer
@@ -145,7 +147,8 @@ func RunProg(prog string, outputLimit, maxRetries int, args ...string) error {
 			return err
 		}
 		glog.Infof("retrying %s %v", prog, args)
-		time.Sleep(backoff)
-		backoff = backoff * 2
+		time.Sleep(time.Duration(backoff) * time.Second)
+		jitter := int(math.Ceil(rand.Float64() * float64(backoff)))
+		backoff = backoff*2 + jitter
 	}
 }

--- a/pkg/util/prog.go
+++ b/pkg/util/prog.go
@@ -1,0 +1,151 @@
+package util
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/golang/glog"
+	"golang.org/x/mod/semver"
+)
+
+const (
+	ItzoGroupID           = 600
+	semverRegexFmt string = `v?([0-9]+)(\.[0-9]+)(\.[0-9]+)?` +
+		`(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))*` +
+		`(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?`
+)
+
+var (
+	semverRegex = regexp.MustCompile("^" + semverRegexFmt + "$")
+	itzoBinPath = "/tmp/itzo/bin"
+)
+
+func versionMatch(exe, minVersion, versionArg string) bool {
+	cmd := exec.Command(exe, versionArg)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		glog.V(2).Infof("%q error getting version: %v", exe, err)
+		return false
+	}
+	version := ""
+	lines := strings.Split(string(output), "\n")
+	for _, line := range lines {
+		for _, word := range strings.Fields(line) {
+			word = strings.TrimRight(word, ",;.")
+			if semverRegex.Match([]byte(word)) {
+				version = word
+				glog.V(2).Infof("%q found version %q (minimum requested: %q)",
+					exe, version, minVersion)
+				return semver.Compare(version, minVersion) >= 0
+			}
+		}
+	}
+	glog.V(2).Infof("%q not found version in output %q", exe, output)
+	return false
+}
+
+func ensurePath(localPath string) {
+	envPath := os.Getenv("PATH")
+	for _, p := range strings.Split(envPath, ":") {
+		if p == localPath {
+			return
+		}
+	}
+	os.Setenv("PATH", envPath+":"+localPath)
+}
+
+func EnsureProg(prog, downloadURL, minVersion, versionArg string) (string, error) {
+	ensurePath(itzoBinPath)
+	exe, err := exec.LookPath(prog)
+	if err == nil {
+		found := versionMatch(exe, minVersion, versionArg)
+		glog.V(5).Infof("looking for %s %s: found %v", exe, minVersion, found)
+		if found {
+			return exe, nil
+		}
+	}
+	// Install into our bin directory in case there is an older version present
+	// in /usr/bin or /usr/local/bin.
+	progBase := filepath.Base(prog)
+	exe = filepath.Join(itzoBinPath, progBase)
+	err = InstallProg(downloadURL, exe)
+	if err != nil {
+		return "", err
+	}
+	return exe, nil
+}
+
+func InstallProg(url, path string) error {
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("creating get request for %s: %+v", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("downloading %s: got status code %d",
+			url, resp.StatusCode)
+	}
+	_ = os.MkdirAll(filepath.Dir(path), 0755)
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0755)
+	if err != nil {
+		return fmt.Errorf("opening %s for writing: %+v", path, err)
+	}
+	defer f.Close()
+	_, err = io.Copy(f, resp.Body)
+	if err != nil {
+		return fmt.Errorf("writing %s: %+v", path, err)
+	}
+	return nil
+}
+
+func RunProg(prog string, outputLimit, maxRetries int, args ...string) error {
+	glog.Infof("running %s with args %v", prog, args)
+	n := 0
+	start := time.Now()
+	backoff := 1 * time.Second
+	for {
+		n++
+		var stderr bytes.Buffer
+		cmd := exec.Command(prog, args...)
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+		cmd.SysProcAttr.Credential = &syscall.Credential{
+			Gid: uint32(ItzoGroupID),
+		}
+		cmd.Stderr = &stderr
+		err := cmd.Run()
+		if err == nil {
+			glog.Infof("%s succeeded after %d attempt(s), %v",
+				prog, n, time.Now().Sub(start))
+			return err
+		}
+		freebs, availbs, serr := GetNumberOfFreeAndAvailableBlocks("/")
+		if serr == nil && (freebs < 5 || availbs < 5) {
+			err = fmt.Errorf(
+				"low disk space, free/available blocks: %d/%d", freebs, availbs)
+			glog.Errorf("running %s: %v", prog, err)
+			return err
+		}
+		output := stderr.String()
+		if len(output) > outputLimit {
+			output = output[len(output)-outputLimit:]
+		}
+		err = fmt.Errorf("%s failed after %d attempt(s): %+v, output:\n%s",
+			prog, n, err, output)
+		glog.Errorf("running %s %v: %v", prog, args, err)
+		if n >= maxRetries {
+			return err
+		}
+		glog.Infof("retrying %s %v", prog, args)
+		time.Sleep(backoff)
+		backoff = backoff * 2
+	}
+}

--- a/pkg/util/prog.go
+++ b/pkg/util/prog.go
@@ -20,7 +20,6 @@ import (
 )
 
 const (
-	ItzoGroupID           = 600
 	semverRegexFmt string = `v?([0-9]+)(\.[0-9]+)(\.[0-9]+)?` +
 		`(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))*` +
 		`(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?`
@@ -119,9 +118,6 @@ func RunProg(prog string, outputLimit, maxRetries int, args ...string) error {
 		var stderr bytes.Buffer
 		cmd := exec.Command(prog, args...)
 		cmd.SysProcAttr = &syscall.SysProcAttr{}
-		cmd.SysProcAttr.Credential = &syscall.Credential{
-			Gid: uint32(ItzoGroupID),
-		}
 		cmd.Stderr = &stderr
 		err := cmd.Run()
 		if err == nil {

--- a/pkg/util/prog_test.go
+++ b/pkg/util/prog_test.go
@@ -1,0 +1,141 @@
+package util
+
+import (
+	"crypto/rand"
+	"fmt"
+	"io/ioutil"
+	"math"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func randStr(t *testing.T) string {
+	n, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
+	assert.NoError(t, err)
+	return strconv.FormatUint(n.Uint64(), 36)
+}
+
+func createScript(t *testing.T, fname, script string) (string, func()) {
+	dir, err := ioutil.TempDir("", "itzo-test-")
+	assert.NoError(t, err)
+	name := filepath.Join(dir, fname)
+	content := []byte("#!/bin/sh\n\n" + script + "\n")
+	err = ioutil.WriteFile(name, content, 0755)
+	assert.NoError(t, err)
+	return name, func() { os.RemoveAll(dir) }
+}
+
+//func EnsureProg(prog, downloadURL, minVersion, versionArg string) (string, error)
+func TestEnsureProg(t *testing.T) {
+	testCases := []struct {
+		Script         string
+		MinimumVersion string
+		Failure        bool
+	}{
+		{
+			Script:         "echo v1.0.0",
+			MinimumVersion: "v1.0.0",
+			Failure:        false,
+		},
+		{
+			Script:         "echo v1.0.0",
+			MinimumVersion: "v0.9.11-asdf+g11",
+			Failure:        false,
+		},
+		{
+			Script:         "echo v1.0.0",
+			MinimumVersion: "v1.0.1",
+			Failure:        true,
+		},
+		{
+			Script:         "echo v0.3.2-beta.1-24-g4e13342-dirty",
+			MinimumVersion: "v0.3.4",
+			Failure:        true,
+		},
+		{
+			Script:         "echo v0.3.2-beta.1-24-g4e13342-dirty",
+			MinimumVersion: "v0.3.1",
+			Failure:        false,
+		},
+		{
+			Script:         "exit 0",
+			MinimumVersion: "v0.3.1",
+			Failure:        true,
+		},
+		{
+			Script:         "echo program version 1.0.0",
+			MinimumVersion: "1.0.0",
+			Failure:        false,
+		},
+		{
+			Script:         "echo program version 1.0.0, built on 202005121109",
+			MinimumVersion: "1.0.0",
+			Failure:        false,
+		},
+	}
+	for _, tc := range testCases {
+		path, closer := createScript(t, randStr(t), tc.Script)
+		defer closer()
+		foundPath, err := EnsureProg(
+			path,
+			"https://whatever.lkj.asdf",
+			tc.MinimumVersion,
+			"--version")
+		if tc.Failure {
+			msg := fmt.Sprintf("Test case %+v not failed as expected", tc)
+			assert.Error(t, err, msg)
+			assert.NotEqual(t, path, foundPath, msg)
+		} else {
+			msg := fmt.Sprintf("Test case %+v failed", tc)
+			assert.NoError(t, err, msg)
+			assert.Equal(t, path, foundPath, msg)
+		}
+	}
+}
+
+//func RunProg(prog string, outputLimit, maxRetries int, args ...string) error
+func TestRunProg(t *testing.T) {
+	testCases := []struct {
+		Script  string
+		Args    []string
+		Failure bool
+	}{
+		{
+			Script:  "echo $@",
+			Args:    []string{"1", "2", "3"},
+			Failure: false,
+		},
+		{
+			Script:  "exit 0",
+			Args:    nil,
+			Failure: false,
+		},
+		{
+			Script:  "exit 1",
+			Args:    nil,
+			Failure: true,
+		},
+		{
+			Script:  "echo foobar; exit 1",
+			Args:    nil,
+			Failure: true,
+		},
+	}
+	for _, tc := range testCases {
+		path, closer := createScript(t, randStr(t), tc.Script)
+		defer closer()
+		err := RunProg(path, 64, 1, tc.Args...)
+		if tc.Failure {
+			msg := fmt.Sprintf("Test case %+v not failed as expected", tc)
+			assert.Error(t, err, msg)
+		} else {
+			msg := fmt.Sprintf("Test case %+v failed", tc)
+			assert.NoError(t, err, msg)
+		}
+	}
+}

--- a/pkg/util/user.go
+++ b/pkg/util/user.go
@@ -100,11 +100,13 @@ func LookupUser(userspec string, lookup UserLookup) (uint32, uint32, string, err
 				groupName, err)
 			grp, err = lookup.LookupGroup(groupName)
 			if err != nil {
-				glog.Errorf("Failed to look up group %q: %v", groupName, err)
-				return 0, 0, "", err
+				// No such group, we will use the user's default group.
+				glog.Warningf("Failed to look up group %q: %v", groupName, err)
 			}
 		}
-		gidStr = grp.Gid
+		if grp != nil {
+			gidStr = grp.Gid
+		}
 	}
 	usr, err := lookup.LookupId(userName)
 	if err != nil {

--- a/vendor/golang.org/x/mod/LICENSE
+++ b/vendor/golang.org/x/mod/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/mod/PATENTS
+++ b/vendor/golang.org/x/mod/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/mod/semver/semver.go
+++ b/vendor/golang.org/x/mod/semver/semver.go
@@ -1,0 +1,388 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package semver implements comparison of semantic version strings.
+// In this package, semantic version strings must begin with a leading "v",
+// as in "v1.0.0".
+//
+// The general form of a semantic version string accepted by this package is
+//
+//	vMAJOR[.MINOR[.PATCH[-PRERELEASE][+BUILD]]]
+//
+// where square brackets indicate optional parts of the syntax;
+// MAJOR, MINOR, and PATCH are decimal integers without extra leading zeros;
+// PRERELEASE and BUILD are each a series of non-empty dot-separated identifiers
+// using only alphanumeric characters and hyphens; and
+// all-numeric PRERELEASE identifiers must not have leading zeros.
+//
+// This package follows Semantic Versioning 2.0.0 (see semver.org)
+// with two exceptions. First, it requires the "v" prefix. Second, it recognizes
+// vMAJOR and vMAJOR.MINOR (with no prerelease or build suffixes)
+// as shorthands for vMAJOR.0.0 and vMAJOR.MINOR.0.
+package semver
+
+// parsed returns the parsed form of a semantic version string.
+type parsed struct {
+	major      string
+	minor      string
+	patch      string
+	short      string
+	prerelease string
+	build      string
+	err        string
+}
+
+// IsValid reports whether v is a valid semantic version string.
+func IsValid(v string) bool {
+	_, ok := parse(v)
+	return ok
+}
+
+// Canonical returns the canonical formatting of the semantic version v.
+// It fills in any missing .MINOR or .PATCH and discards build metadata.
+// Two semantic versions compare equal only if their canonical formattings
+// are identical strings.
+// The canonical invalid semantic version is the empty string.
+func Canonical(v string) string {
+	p, ok := parse(v)
+	if !ok {
+		return ""
+	}
+	if p.build != "" {
+		return v[:len(v)-len(p.build)]
+	}
+	if p.short != "" {
+		return v + p.short
+	}
+	return v
+}
+
+// Major returns the major version prefix of the semantic version v.
+// For example, Major("v2.1.0") == "v2".
+// If v is an invalid semantic version string, Major returns the empty string.
+func Major(v string) string {
+	pv, ok := parse(v)
+	if !ok {
+		return ""
+	}
+	return v[:1+len(pv.major)]
+}
+
+// MajorMinor returns the major.minor version prefix of the semantic version v.
+// For example, MajorMinor("v2.1.0") == "v2.1".
+// If v is an invalid semantic version string, MajorMinor returns the empty string.
+func MajorMinor(v string) string {
+	pv, ok := parse(v)
+	if !ok {
+		return ""
+	}
+	i := 1 + len(pv.major)
+	if j := i + 1 + len(pv.minor); j <= len(v) && v[i] == '.' && v[i+1:j] == pv.minor {
+		return v[:j]
+	}
+	return v[:i] + "." + pv.minor
+}
+
+// Prerelease returns the prerelease suffix of the semantic version v.
+// For example, Prerelease("v2.1.0-pre+meta") == "-pre".
+// If v is an invalid semantic version string, Prerelease returns the empty string.
+func Prerelease(v string) string {
+	pv, ok := parse(v)
+	if !ok {
+		return ""
+	}
+	return pv.prerelease
+}
+
+// Build returns the build suffix of the semantic version v.
+// For example, Build("v2.1.0+meta") == "+meta".
+// If v is an invalid semantic version string, Build returns the empty string.
+func Build(v string) string {
+	pv, ok := parse(v)
+	if !ok {
+		return ""
+	}
+	return pv.build
+}
+
+// Compare returns an integer comparing two versions according to
+// semantic version precedence.
+// The result will be 0 if v == w, -1 if v < w, or +1 if v > w.
+//
+// An invalid semantic version string is considered less than a valid one.
+// All invalid semantic version strings compare equal to each other.
+func Compare(v, w string) int {
+	pv, ok1 := parse(v)
+	pw, ok2 := parse(w)
+	if !ok1 && !ok2 {
+		return 0
+	}
+	if !ok1 {
+		return -1
+	}
+	if !ok2 {
+		return +1
+	}
+	if c := compareInt(pv.major, pw.major); c != 0 {
+		return c
+	}
+	if c := compareInt(pv.minor, pw.minor); c != 0 {
+		return c
+	}
+	if c := compareInt(pv.patch, pw.patch); c != 0 {
+		return c
+	}
+	return comparePrerelease(pv.prerelease, pw.prerelease)
+}
+
+// Max canonicalizes its arguments and then returns the version string
+// that compares greater.
+func Max(v, w string) string {
+	v = Canonical(v)
+	w = Canonical(w)
+	if Compare(v, w) > 0 {
+		return v
+	}
+	return w
+}
+
+func parse(v string) (p parsed, ok bool) {
+	if v == "" || v[0] != 'v' {
+		p.err = "missing v prefix"
+		return
+	}
+	p.major, v, ok = parseInt(v[1:])
+	if !ok {
+		p.err = "bad major version"
+		return
+	}
+	if v == "" {
+		p.minor = "0"
+		p.patch = "0"
+		p.short = ".0.0"
+		return
+	}
+	if v[0] != '.' {
+		p.err = "bad minor prefix"
+		ok = false
+		return
+	}
+	p.minor, v, ok = parseInt(v[1:])
+	if !ok {
+		p.err = "bad minor version"
+		return
+	}
+	if v == "" {
+		p.patch = "0"
+		p.short = ".0"
+		return
+	}
+	if v[0] != '.' {
+		p.err = "bad patch prefix"
+		ok = false
+		return
+	}
+	p.patch, v, ok = parseInt(v[1:])
+	if !ok {
+		p.err = "bad patch version"
+		return
+	}
+	if len(v) > 0 && v[0] == '-' {
+		p.prerelease, v, ok = parsePrerelease(v)
+		if !ok {
+			p.err = "bad prerelease"
+			return
+		}
+	}
+	if len(v) > 0 && v[0] == '+' {
+		p.build, v, ok = parseBuild(v)
+		if !ok {
+			p.err = "bad build"
+			return
+		}
+	}
+	if v != "" {
+		p.err = "junk on end"
+		ok = false
+		return
+	}
+	ok = true
+	return
+}
+
+func parseInt(v string) (t, rest string, ok bool) {
+	if v == "" {
+		return
+	}
+	if v[0] < '0' || '9' < v[0] {
+		return
+	}
+	i := 1
+	for i < len(v) && '0' <= v[i] && v[i] <= '9' {
+		i++
+	}
+	if v[0] == '0' && i != 1 {
+		return
+	}
+	return v[:i], v[i:], true
+}
+
+func parsePrerelease(v string) (t, rest string, ok bool) {
+	// "A pre-release version MAY be denoted by appending a hyphen and
+	// a series of dot separated identifiers immediately following the patch version.
+	// Identifiers MUST comprise only ASCII alphanumerics and hyphen [0-9A-Za-z-].
+	// Identifiers MUST NOT be empty. Numeric identifiers MUST NOT include leading zeroes."
+	if v == "" || v[0] != '-' {
+		return
+	}
+	i := 1
+	start := 1
+	for i < len(v) && v[i] != '+' {
+		if !isIdentChar(v[i]) && v[i] != '.' {
+			return
+		}
+		if v[i] == '.' {
+			if start == i || isBadNum(v[start:i]) {
+				return
+			}
+			start = i + 1
+		}
+		i++
+	}
+	if start == i || isBadNum(v[start:i]) {
+		return
+	}
+	return v[:i], v[i:], true
+}
+
+func parseBuild(v string) (t, rest string, ok bool) {
+	if v == "" || v[0] != '+' {
+		return
+	}
+	i := 1
+	start := 1
+	for i < len(v) {
+		if !isIdentChar(v[i]) && v[i] != '.' {
+			return
+		}
+		if v[i] == '.' {
+			if start == i {
+				return
+			}
+			start = i + 1
+		}
+		i++
+	}
+	if start == i {
+		return
+	}
+	return v[:i], v[i:], true
+}
+
+func isIdentChar(c byte) bool {
+	return 'A' <= c && c <= 'Z' || 'a' <= c && c <= 'z' || '0' <= c && c <= '9' || c == '-'
+}
+
+func isBadNum(v string) bool {
+	i := 0
+	for i < len(v) && '0' <= v[i] && v[i] <= '9' {
+		i++
+	}
+	return i == len(v) && i > 1 && v[0] == '0'
+}
+
+func isNum(v string) bool {
+	i := 0
+	for i < len(v) && '0' <= v[i] && v[i] <= '9' {
+		i++
+	}
+	return i == len(v)
+}
+
+func compareInt(x, y string) int {
+	if x == y {
+		return 0
+	}
+	if len(x) < len(y) {
+		return -1
+	}
+	if len(x) > len(y) {
+		return +1
+	}
+	if x < y {
+		return -1
+	} else {
+		return +1
+	}
+}
+
+func comparePrerelease(x, y string) int {
+	// "When major, minor, and patch are equal, a pre-release version has
+	// lower precedence than a normal version.
+	// Example: 1.0.0-alpha < 1.0.0.
+	// Precedence for two pre-release versions with the same major, minor,
+	// and patch version MUST be determined by comparing each dot separated
+	// identifier from left to right until a difference is found as follows:
+	// identifiers consisting of only digits are compared numerically and
+	// identifiers with letters or hyphens are compared lexically in ASCII
+	// sort order. Numeric identifiers always have lower precedence than
+	// non-numeric identifiers. A larger set of pre-release fields has a
+	// higher precedence than a smaller set, if all of the preceding
+	// identifiers are equal.
+	// Example: 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta <
+	// 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0."
+	if x == y {
+		return 0
+	}
+	if x == "" {
+		return +1
+	}
+	if y == "" {
+		return -1
+	}
+	for x != "" && y != "" {
+		x = x[1:] // skip - or .
+		y = y[1:] // skip - or .
+		var dx, dy string
+		dx, x = nextIdent(x)
+		dy, y = nextIdent(y)
+		if dx != dy {
+			ix := isNum(dx)
+			iy := isNum(dy)
+			if ix != iy {
+				if ix {
+					return -1
+				} else {
+					return +1
+				}
+			}
+			if ix {
+				if len(dx) < len(dy) {
+					return -1
+				}
+				if len(dx) > len(dy) {
+					return +1
+				}
+			}
+			if dx < dy {
+				return -1
+			} else {
+				return +1
+			}
+		}
+	}
+	if x == "" {
+		return -1
+	} else {
+		return +1
+	}
+}
+
+func nextIdent(x string) (dx, rest string) {
+	i := 0
+	for i < len(x) && x[i] != '.' {
+		i++
+	}
+	return x[:i], x[i:]
+}


### PR DESCRIPTION
I created an ImageClient interface to abstract away image pulling and extraction, then added implementations for tosi and img. Right now img is not functional, since I couldn't find a way to get the image config after pulling.

I also added the ability to check for minimum required versions when running external programs. To speed up image pulling, itzo now relies on tosi >= 0.0.3 so the image layers can be mounted via overlayfs.