### PR TITLE
add some fallback logic for getting docker registry creds

### DIFF
--- a/pkg/server/pod_controller.go
+++ b/pkg/server/pod_controller.go
@@ -410,16 +410,20 @@ func (pc *PodController) saveUnitConfig(unit *api.Unit, podSecurityContext *api.
 	return nil
 }
 
-// Dockerhub can go by several names that the user can specify the
-// .docker/config.json uses index.docker.io but an empty server should
-// also map to that. We have used registry-1.docker.io internally. Users
-// might also just say "docker.io"
+// Dockerhub can go by several names that the user can specify in
+// their image spec.  .docker/config.json uses index.docker.io but an
+// empty server should also map to that. We have used
+// registry-1.docker.io internally and users might also just say
+// "docker.io".  Try to find the server that shows up in the
+// credentials sent over from kip.
 func getRepoCreds(server string, allCreds map[string]api.RegistryCredentials) (string, string) {
 	if creds, ok := allCreds[server]; ok {
 		return creds.Username, creds.Password
 	}
-	// if no server, try to find credentials for (in this order):
-	// index.docker.io, registry-1.docker.io, docker.io
+	// if credentials weren't found and the server is dockerhub
+	// (server is empty or ends in docker.io), try to find credentials
+	// for (in this order): index.docker.io, registry-1.docker.io,
+	// docker.io
 	if server == "" || strings.HasSuffix(server, "docker.io") {
 		possibleServers := []string{"index.docker.io", "registry-1.docker.io", "docker.io"}
 		for _, possibleServer := range possibleServers {

--- a/pkg/server/pod_controller_test.go
+++ b/pkg/server/pod_controller_test.go
@@ -698,3 +698,47 @@ func TestWaitForInitUnitReturnCases(t *testing.T) {
 		cancel()
 	}
 }
+
+func TestGetRepoCreds(t *testing.T) {
+	tests := []struct {
+		server string
+		creds  map[string]api.RegistryCredentials
+		u      string
+		p      string
+	}{
+		{
+			server: "",
+			creds:  nil,
+			u:      "",
+			p:      "",
+		},
+		{
+			server: "",
+			creds: map[string]api.RegistryCredentials{
+				"index.docker.io": api.RegistryCredentials{
+					Username: "myuser",
+					Password: "mypass",
+				},
+			},
+			u: "myuser",
+			p: "mypass",
+		},
+		{
+			server: "docker.io",
+			creds: map[string]api.RegistryCredentials{
+				"registry-1.docker.io": api.RegistryCredentials{
+					Username: "myuser",
+					Password: "mypass",
+				},
+			},
+			u: "myuser",
+			p: "mypass",
+		},
+	}
+	for i, tc := range tests {
+		user, pass := getRepoCreds(tc.server, tc.creds)
+		msg := fmt.Sprintf("test case %d failed", i)
+		assert.Equal(t, tc.u, user, msg)
+		assert.Equal(t, tc.p, pass, msg)
+	}
+}


### PR DESCRIPTION
Adding some fallback logic for the myriad ways you can name the server/host in a docker image spec. We need to match the image's server up with credentials supplied through a secret created from `$HOME/.docker/config.json`  That secret currently specifies the docker server as `https://index.docker.io/v1/` which gets transmitted to itzo as `index.docker.io` along with credentials for that server.  Users can also use `registry-1.docker.io`, `docker.io` or nothing as hosts in their image names.

I'm unsure what the user's `config.json` has specified so I added code to see if we have credentials for any of the three docker hostnames I've seen used.