### PR TITLE
Clean up pkg/server/util.go

### DIFF
--- a/pkg/host/networkagent.go
+++ b/pkg/host/networkagent.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 Elotl Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package host
 
 import (

--- a/pkg/host/networkagent.go
+++ b/pkg/host/networkagent.go
@@ -1,0 +1,86 @@
+package host
+
+import (
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+
+	"github.com/elotl/itzo/pkg/util"
+	"github.com/golang/glog"
+)
+
+const (
+	KubeRouterProg           = "kube-router"
+	KubeRouterURL            = "https://milpa-builds.s3.amazonaws.com/kube-router"
+	KubeRouterMinimumVersion = "v0.3.1"
+)
+
+func EnsureNetworkAgent(IP, nodeName, baseDir string) *exec.Cmd {
+	pth, err := util.EnsureProg(
+		KubeRouterProg, KubeRouterURL, KubeRouterMinimumVersion, "--version")
+	if err != nil {
+		glog.Errorf("failed to look up path of %q: %v", KubeRouterProg, err)
+		return nil
+	}
+	// Kubeconfig has been deployed as a package. Find the actual config file
+	// inside the package directory.
+	kubeconfig := ""
+	kubeconfigDir := path.Join(baseDir, "packages/kubeconfig")
+	err = filepath.Walk(
+		kubeconfigDir,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				return nil
+			}
+			if info.Name() == "kubeconfig" {
+				kubeconfig = path
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		glog.Errorf("searching for kubeconfig package: %v", err)
+		return nil
+	}
+	if kubeconfig == "" {
+		glog.Errorf("no kubeconfig found")
+		return nil
+	}
+	err = os.MkdirAll("/var/log", 0755)
+	if err != nil {
+		glog.Warningf("ensuring /var/log exists: %v", err)
+	}
+	logfile, err := os.OpenFile(
+		"/var/log/kube-router.log", os.O_RDWR|os.O_APPEND|os.O_CREATE, 0600)
+	if err != nil {
+		glog.Warningf("opening kube-router logfile: %v", err)
+	}
+	if logfile != nil {
+		defer logfile.Close()
+	}
+	cmd := exec.Command(
+		pth,
+		"--kubeconfig="+kubeconfig,
+		"--hostname-override="+nodeName,
+		"--ip-address-override="+IP,
+		"--hairpin-mode=true",
+		"--disable-source-dest-check=false",
+		"--enable-pod-egress=false",
+		"--enable-cni=false",
+		"--run-router=false",
+		"--v=2",
+	)
+	cmd.Stdout = logfile
+	cmd.Stderr = logfile
+	err = cmd.Start()
+	if err != nil {
+		glog.Errorf("starting %v: %v", cmd, err)
+		return nil
+	}
+	glog.Infof("%v started", cmd)
+	return cmd
+}

--- a/pkg/host/nvidia.go
+++ b/pkg/host/nvidia.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 Elotl Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package host
 
 import (

--- a/pkg/host/nvidia.go
+++ b/pkg/host/nvidia.go
@@ -1,0 +1,72 @@
+package host
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+
+	"github.com/elotl/itzo/pkg/util"
+	"github.com/golang/glog"
+)
+
+const (
+	NvidiaContainerCli               = "nvidia-container-cli"
+	NvidiaContainerCliDownloadURL    = "https://s3.amazonaws.com/itzo-packages/nvidia-container-cli"
+	NvidiaContainerCliMinimumVersion = "1.0.2"
+	NvidiaContainerCliVersionFlag    = "--version"
+	NvidiaSMI                        = "nvidia-smi"
+)
+
+// See https://nvidia.github.io/libnvidia-container/ on how to install
+// nvidia-container-cli. We add it to our Ubuntu-based images.
+func InitializeGPU(rootfs string) error {
+	if _, err := os.Stat("/dev/nvidiactl"); err != nil {
+		if os.IsNotExist(err) {
+			// Not a GPU instance.
+			return nil
+		}
+		glog.Errorf("Checking /dev/nvidiactl: %v", err)
+		return err
+	}
+	cli, err := util.EnsureProg(
+		NvidiaContainerCli,
+		NvidiaContainerCliDownloadURL,
+		NvidiaContainerCliMinimumVersion,
+		NvidiaContainerCliVersionFlag,
+	)
+	if err != nil {
+		glog.Errorf("Looking up %s: %v", NvidiaContainerCli, err)
+		return err
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	// Run nvidia-smi first, since it does some initialization without which
+	// nvidia-container-cli will fail.
+	cmd := exec.Command(NvidiaSMI)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err = cmd.Run(); err != nil {
+		glog.Errorf("Running %+v: %v stderr:\n%s", cmd, err, stderr.String())
+		return err
+	}
+	stdout.Reset()
+	stderr.Reset()
+	args := []string{
+		"configure",
+		"--compute",
+		"--no-cgroups",
+		"--no-devbind",
+		"--utility",
+		//		"--ldconfig",
+		//		"/usr/glibc-compat/sbin/ldconfig",
+		rootfs,
+	}
+	cmd = exec.Command(cli, args...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err = cmd.Run(); err != nil {
+		glog.Errorf("Running %+v: %v stderr:\n%s", cmd, err, stderr.String())
+		return err
+	}
+	return nil
+}

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 Elotl Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package image
 
 type ImageClient interface {

--- a/pkg/image/img.go
+++ b/pkg/image/img.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 Elotl Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package image
 
 import (

--- a/pkg/image/tosi.go
+++ b/pkg/image/tosi.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 Elotl Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package image
 
 import (

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -38,6 +38,7 @@ import (
 	"time"
 
 	"github.com/elotl/itzo/pkg/api"
+	"github.com/elotl/itzo/pkg/host"
 	"github.com/elotl/itzo/pkg/logbuf"
 	"github.com/elotl/itzo/pkg/metrics"
 	"github.com/elotl/itzo/pkg/mount"
@@ -161,7 +162,7 @@ func (s *Server) statusHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) startNetworkAgent(IP, nodeName string) {
-	cmd := runNetworkAgent(IP, nodeName)
+	cmd := host.EnsureNetworkAgent(IP, nodeName, ITZO_DIR)
 	if cmd == nil {
 		return
 	}

--- a/pkg/server/unit.go
+++ b/pkg/server/unit.go
@@ -31,6 +31,7 @@ import (
 	"github.com/containerd/cgroups"
 	"github.com/elotl/itzo/pkg/api"
 	"github.com/elotl/itzo/pkg/caps"
+	"github.com/elotl/itzo/pkg/host"
 	imagecli "github.com/elotl/itzo/pkg/image"
 	"github.com/elotl/itzo/pkg/mount"
 	"github.com/elotl/itzo/pkg/prober"
@@ -867,8 +868,8 @@ func (u *Unit) applySysctls() error {
 	return nil
 }
 
-func (u *Unit) setupGpu() error {
-	return setupGpu(u.GetRootfs())
+func (u *Unit) initializeGPU() error {
+	return host.InitializeGPU(u.GetRootfs())
 }
 
 func (u *Unit) Run(podname, hostname string, command []string, workingdir string, policy api.RestartPolicy, mounter mount.Mounter) error {
@@ -976,8 +977,8 @@ func (u *Unit) Run(podname, hostname string, command []string, workingdir string
 		//  rootfs of the unit. If this is a GPU instance, we'll have to do
 		//  some extra steps for setting up the unit (mounting in the right
 		//  version of support libraries, etc) before calling pivot_root().
-		if err := u.setupGpu(); err != nil {
-			glog.Errorf("setupGpu(): %v", err)
+		if err := u.initializeGPU(); err != nil {
+			glog.Errorf("initializeGPU(): %v", err)
 			mounter.UnmountSpecial(u.Name)
 			u.setStateToStartFailure(err)
 			return err

--- a/pkg/server/util.go
+++ b/pkg/server/util.go
@@ -26,19 +26,14 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
 
-	"github.com/elotl/itzo/pkg/util"
 	"github.com/golang/glog"
 )
 
 var (
-	KubeRouterProg                 = "kube-router"
-	KubeRouterURL                  = "https://milpa-builds.s3.amazonaws.com/kube-router"
-	KubeRouterMinimumVersion       = "v0.3.1"
 	MaxBufferSize            int64 = 1024 * 1024 * 10 // 10MB
 	NVIDIA_CONTAINER_CLI_PRG       = "nvidia-container-cli"
 	NVIDIA_SMI_PRG                 = "nvidia-smi"
@@ -157,75 +152,6 @@ func ensureFileExists(name string) error {
 	}
 	f.Close()
 	return nil
-}
-
-func runNetworkAgent(IP, nodeName string) *exec.Cmd {
-	pth, err := util.EnsureProg(
-		KubeRouterProg, KubeRouterURL, KubeRouterMinimumVersion, "--version")
-	if err != nil {
-		glog.Errorf("failed to look up path of %q: %v", KubeRouterProg, err)
-		return nil
-	}
-	// Kubeconfig has been deployed as a package. Find the actual config file
-	// inside the package directory.
-	kubeconfig := ""
-	kubeconfigDir := path.Join(ITZO_DIR, "packages/kubeconfig")
-	err = filepath.Walk(
-		kubeconfigDir,
-		func(path string, info os.FileInfo, err error) error {
-			if err != nil {
-				return err
-			}
-			if info.IsDir() {
-				return nil
-			}
-			if info.Name() == "kubeconfig" {
-				kubeconfig = path
-			}
-			return nil
-		},
-	)
-	if err != nil {
-		glog.Errorf("searching for kubeconfig package: %v", err)
-		return nil
-	}
-	if kubeconfig == "" {
-		glog.Errorf("no kubeconfig found")
-		return nil
-	}
-	err = os.MkdirAll("/var/log", 0755)
-	if err != nil {
-		glog.Warningf("ensuring /var/log exists: %v", err)
-	}
-	logfile, err := os.OpenFile(
-		"/var/log/kube-router.log", os.O_RDWR|os.O_APPEND|os.O_CREATE, 0600)
-	if err != nil {
-		glog.Warningf("opening kube-router logfile: %v", err)
-	}
-	if logfile != nil {
-		defer logfile.Close()
-	}
-	cmd := exec.Command(
-		pth,
-		"--kubeconfig="+kubeconfig,
-		"--hostname-override="+nodeName,
-		"--ip-address-override="+IP,
-		"--hairpin-mode=true",
-		"--disable-source-dest-check=false",
-		"--enable-pod-egress=false",
-		"--enable-cni=false",
-		"--run-router=false",
-		"--v=2",
-	)
-	cmd.Stdout = logfile
-	cmd.Stderr = logfile
-	err = cmd.Start()
-	if err != nil {
-		glog.Errorf("starting %v: %v", cmd, err)
-		return nil
-	}
-	glog.Infof("%v started", cmd)
-	return cmd
 }
 
 // I have no idea why I wrote this...  I mean, the host tail

--- a/pkg/server/util.go
+++ b/pkg/server/util.go
@@ -34,9 +34,7 @@ import (
 )
 
 var (
-	MaxBufferSize            int64 = 1024 * 1024 * 10 // 10MB
-	NVIDIA_CONTAINER_CLI_PRG       = "nvidia-container-cli"
-	NVIDIA_SMI_PRG                 = "nvidia-smi"
+	MaxBufferSize int64 = 1024 * 1024 * 10 // 10MB
 )
 
 func copyFile(src, dst string) error {
@@ -380,52 +378,5 @@ func doDeployPackage(filename, destdir string) (err error) {
 		}
 	}
 
-	return nil
-}
-
-func setupGpu(rootfs string) error {
-	if _, err := os.Stat("/dev/nvidiactl"); err != nil {
-		if os.IsNotExist(err) {
-			// Not a GPU instance.
-			return nil
-		}
-		glog.Errorf("Checking /dev/nvidiactl: %v", err)
-		return err
-	}
-	cli, err := exec.LookPath(NVIDIA_CONTAINER_CLI_PRG)
-	if err != nil {
-		glog.Errorf("Looking up %s: %v", NVIDIA_CONTAINER_CLI_PRG, err)
-		return err
-	}
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	// Run nvidia-smi first, since it does some initialization without which
-	// nvidia-container-cli will fail.
-	cmd := exec.Command(NVIDIA_SMI_PRG)
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err = cmd.Run(); err != nil {
-		glog.Errorf("Running %+v: %v stderr:\n%s", cmd, err, stderr.String())
-		return err
-	}
-	stdout.Reset()
-	stderr.Reset()
-	args := []string{
-		"configure",
-		"--compute",
-		"--no-cgroups",
-		"--no-devbind",
-		"--utility",
-		//		"--ldconfig",
-		//		"/usr/glibc-compat/sbin/ldconfig",
-		rootfs,
-	}
-	cmd = exec.Command(cli, args...)
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err = cmd.Run(); err != nil {
-		glog.Errorf("Running %+v: %v stderr:\n%s", cmd, err, stderr.String())
-		return err
-	}
 	return nil
 }

--- a/pkg/util/kill/kill.go
+++ b/pkg/util/kill/kill.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 Elotl Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package kill
 
 import (

--- a/pkg/util/kill/kill_test.go
+++ b/pkg/util/kill/kill_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 Elotl Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package kill
 
 import (

--- a/pkg/util/prog.go
+++ b/pkg/util/prog.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 Elotl Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package util
 
 import (

--- a/pkg/util/prog_test.go
+++ b/pkg/util/prog_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 Elotl Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package util
 
 import (


### PR DESCRIPTION
We've accumulated a bit of cruft in pkg/server/util.go. To clean up things, I've moved the network agent setup and GPU initialization related bits of code to a new package, pkg/host.