### PR TITLE
Sanitize logs

### DIFF
--- a/pkg/host/networkagent.go
+++ b/pkg/host/networkagent.go
@@ -94,9 +94,9 @@ func EnsureNetworkAgent(IP, nodeName, baseDir string) *exec.Cmd {
 	cmd.Stderr = logfile
 	err = cmd.Start()
 	if err != nil {
-		glog.Errorf("starting %v: %v", cmd, err)
+		glog.Errorf("starting %s: %v", pth, err)
 		return nil
 	}
-	glog.Infof("%v started", cmd)
+	glog.Infof("%s started", pth)
 	return cmd
 }

--- a/pkg/host/nvidia.go
+++ b/pkg/host/nvidia.go
@@ -41,7 +41,7 @@ func InitializeGPU(rootfs string) error {
 			// Not a GPU instance.
 			return nil
 		}
-		glog.Errorf("Checking /dev/nvidiactl: %v", err)
+		glog.Errorf("checking /dev/nvidiactl: %v", err)
 		return err
 	}
 	cli, err := util.EnsureProg(
@@ -51,7 +51,7 @@ func InitializeGPU(rootfs string) error {
 		NvidiaContainerCliVersionFlag,
 	)
 	if err != nil {
-		glog.Errorf("Looking up %s: %v", NvidiaContainerCli, err)
+		glog.Errorf("looking up %s: %v", NvidiaContainerCli, err)
 		return err
 	}
 	var stdout bytes.Buffer
@@ -62,7 +62,7 @@ func InitializeGPU(rootfs string) error {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err = cmd.Run(); err != nil {
-		glog.Errorf("Running %+v: %v stderr:\n%s", cmd, err, stderr.String())
+		glog.Errorf("running %s: %v stderr:\n%s", NvidiaSMI, err, stderr.String())
 		return err
 	}
 	stdout.Reset()
@@ -81,7 +81,7 @@ func InitializeGPU(rootfs string) error {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err = cmd.Run(); err != nil {
-		glog.Errorf("Running %+v: %v stderr:\n%s", cmd, err, stderr.String())
+		glog.Errorf("running %s: %v stderr:\n%s", NvidiaSMI, err, stderr.String())
 		return err
 	}
 	return nil

--- a/pkg/image/tosi.go
+++ b/pkg/image/tosi.go
@@ -26,8 +26,8 @@ const (
 	TosiMaxRetries     = 3
 	TosiOutputLimit    = 4096
 	TosiExe            = "tosi"
-	TosiMinimumVersion = "v0.0.3"
-	TosiURL            = "https://github.com/elotl/tosi/releases/download/v0.0.3/tosi-amd64"
+	TosiMinimumVersion = "v0.0.7"
+	TosiURL            = "https://github.com/elotl/tosi/releases/download/v0.0.7/tosi-amd64"
 )
 
 type Tosi struct {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -633,7 +633,7 @@ func (s *Server) serveAttach(w http.ResponseWriter, r *http.Request) {
 func (s *Server) serveExec(w http.ResponseWriter, r *http.Request) {
 	ws, err := s.doUpgrade(w, r)
 	if err != nil {
-		glog.Errorf("Failed to upgrade WS connection for exec: %v", err)
+		glog.Errorf("upgrading WS connection for exec: %v", err)
 		return
 	}
 	defer ws.CloseAndCleanup()
@@ -641,7 +641,7 @@ func (s *Server) serveExec(w http.ResponseWriter, r *http.Request) {
 	var params api.ExecParams
 	err = getInitialParams(ws, &params)
 	if err != nil {
-		glog.Errorf("Failed to get initial parameters for exec: %v", err)
+		glog.Errorf("getting initial parameters for exec: %v", err)
 		return
 	}
 
@@ -663,7 +663,7 @@ func (s *Server) runcmdHandler(w http.ResponseWriter, r *http.Request) {
 	cmd := exec.Command(params.Command[0], params.Command[1:]...)
 	output, err := cmd.Output()
 	if err != nil {
-		serverError(w, fmt.Errorf("Error running command: %v", err))
+		serverError(w, fmt.Errorf("running command %s: %v", err, params.Command[0]))
 		return
 	}
 	// Todo: do we need to base64 encode the output from the command?

--- a/pkg/server/unit_manager.go
+++ b/pkg/server/unit_manager.go
@@ -197,8 +197,7 @@ func (um *UnitManager) StartUnit(podname, hostname, unitname, workingdir, netns 
 	}
 	cmd.Env = env
 
-	glog.Infof("Unit %q workingdir %q command %v %v env %v policy %v",
-		unitname, workingdir, command, args, env, policy)
+	glog.Infof("unit %q workingdir %q policy %v", unitname, workingdir, policy)
 
 	// Check if a chroot exists for the unit. If it does, a package has been
 	// deployed there with a complete root filesystem, and we need to run our
@@ -223,7 +222,7 @@ func (um *UnitManager) StartUnit(podname, hostname, unitname, workingdir, netns 
 	um.CaptureLogs(podname, unitname, unit.LogPipe)
 
 	if err = cmd.Start(); err != nil {
-		glog.Errorf("Failed to start %+v: %v", cmd, err)
+		glog.Errorf("Failed to start %s/%s: %v", podname, unitname, err)
 		unit.LogPipe.Remove()
 		return err
 	}
@@ -232,9 +231,9 @@ func (um *UnitManager) StartUnit(podname, hostname, unitname, workingdir, netns 
 	go func() {
 		err = cmd.Wait()
 		if err == nil {
-			glog.Infof("Unit %v (helper pid %d) exited", command, pid)
+			glog.Infof("unit %s/%s (helper pid %d) exited", podname, unitname, pid)
 		} else {
-			glog.Errorf("Unit %v (helper pid %d) exited with error %v", command, pid, err)
+			glog.Errorf("unit %s/%s (helper pid %d) exited with error %v", podname, unitname, pid, err)
 		}
 		um.runningUnits.Delete(unitname)
 		unit.LogPipe.Remove()

--- a/pkg/util/prog.go
+++ b/pkg/util/prog.go
@@ -125,7 +125,7 @@ func InstallProg(url, path string) error {
 }
 
 func RunProg(prog string, outputLimit, maxRetries int, args ...string) error {
-	glog.Infof("running %s with args %v", prog, args)
+	glog.Infof("running %s", prog)
 	n := 0
 	start := time.Now()
 	backoff := 3
@@ -154,11 +154,11 @@ func RunProg(prog string, outputLimit, maxRetries int, args ...string) error {
 		}
 		err = fmt.Errorf("%s failed after %d attempt(s): %+v, output:\n%s",
 			prog, n, err, output)
-		glog.Errorf("running %s %v: %v", prog, args, err)
+		glog.Errorf("running %s: %v", prog, err)
 		if n >= maxRetries {
 			return err
 		}
-		glog.Infof("retrying %s %v", prog, args)
+		glog.Infof("retrying %s", prog)
 		time.Sleep(time.Duration(backoff) * time.Second)
 		jitter := int(math.Ceil(rand.Float64() * float64(backoff)))
 		backoff = backoff*2 + jitter


### PR DESCRIPTION
I checked logging, and changed it everywhere where a command parameter or environment variable might have been logged to ensure no sensitive information is leaked via itzo logs.

I also made some cosmetic changes to better align with logging conventions (log lines starting lower case, removing redundant "error" and "failed" words).