### PR TITLE
Fill in memoryAvailable when unit has no limit

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -139,6 +139,10 @@ func (m *Metrics) GetUnitMetrics(name string) api.ResourceMetrics {
 		limit := m.Usage.Limit
 		if !isMemoryUnlimited(limit) {
 			metrics[name+".memoryAvailable"] = float64(limit - workingSet)
+		} else {
+			if sysMem, err := mem.VirtualMemory(); err == nil {
+				metrics[name+".memoryAvailable"] = float64(sysMem.Available)
+			}
 		}
 	}
 	return metrics


### PR DESCRIPTION
We use the resource limit as the maximum available memory when reporting
unit metrics. However, this means that "<unit>.memoryAvailable" will not
be available if there is not memory limit set. In that case, check
available system memory as a fallback.