### PR TITLE
Bcox catch resize errors

### DIFF
--- a/pkg/server/util.go
+++ b/pkg/server/util.go
@@ -130,11 +130,11 @@ func resizeVolume() error {
 		}
 		out, err = exec.Command("growpart", rootDevice, partitionNumber).CombinedOutput()
 		if err != nil {
-			if strings.Contains(string(out), "NOCHANGE") ||
+			if strings.Contains(string(out), "NOCHANGE") &&
 				strings.Contains(string(out), "cannot be grown") {
-				glog.Warningf("Partition already resized: %s: %s", out, err.Error())
+				glog.Warningf("partition already resized: %s: %s", out, err.Error())
 			} else {
-				err = fmt.Errorf("Could not grow root partition: %v, %s", err, string(out))
+				err = fmt.Errorf("could not grow root partition: %v, %s", err, string(out))
 				glog.Error(err)
 				return err
 			}

--- a/pkg/server/util.go
+++ b/pkg/server/util.go
@@ -30,7 +30,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/elotl/kip/pkg/util"
+	"github.com/elotl/itzo/pkg/util"
 	"github.com/golang/glog"
 )
 

--- a/pkg/server/util.go
+++ b/pkg/server/util.go
@@ -30,8 +30,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/elotl/itzo/pkg/util"
 	"github.com/golang/glog"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -84,7 +84,7 @@ func getPartitionNumber(dev string) (string, error) {
 func resizeVolume() error {
 	mounts, err := os.Open("/proc/mounts")
 	if err != nil {
-		err = util.WrapError(err, "opening /proc/mounts")
+		err = errors.Wrap(err, "opening /proc/mounts")
 		glog.Error(err)
 		return err
 	}
@@ -103,7 +103,7 @@ func resizeVolume() error {
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		err = util.WrapError(err, "reading /proc/mounts")
+		err = errors.Wrap(err, "reading /proc/mounts")
 		glog.Error(err.Error())
 		return err
 	}
@@ -115,7 +115,7 @@ func resizeVolume() error {
 	// Grab the root partition's raw device (e.g. /dev/nvme0n1)
 	out, err := exec.Command("lsblk", "-no", "pkname", rootPartition).Output()
 	if err != nil {
-		err = util.WrapError(err, "Could not get the root partition's root block device:")
+		err = errors.Wrap(err, "Could not get the root partition's root block device:")
 		glog.Error(err)
 		return err
 	}
@@ -153,12 +153,12 @@ func resizeVolume() error {
 		cmd.Stderr = io.MultiWriter(os.Stderr, &errbuf)
 		glog.Infof("trying to resize %s", rootPartition)
 		if err := cmd.Start(); err != nil {
-			err = util.WrapError(err, "resize2fs %s", rootPartition)
+			err = errors.Wrapf(err, "resize2fs %s", rootPartition)
 			glog.Error(err)
 			return err
 		}
 		if err := cmd.Wait(); err != nil {
-			err = util.WrapError(err, "resize2fs %s: stdout: %s stderr: %s", rootPartition, outbuf.String(), errbuf.String())
+			err = errors.Wrapf(err, "resize2fs %s: stdout: %s stderr: %s", rootPartition, outbuf.String(), errbuf.String())
 			glog.Error(err)
 			return err
 		}

--- a/pkg/server/util.go
+++ b/pkg/server/util.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/elotl/kip/pkg/util"
 	"github.com/golang/glog"
 )
 
@@ -83,7 +84,8 @@ func getPartitionNumber(dev string) (string, error) {
 func resizeVolume() error {
 	mounts, err := os.Open("/proc/mounts")
 	if err != nil {
-		glog.Errorf("opening /proc/mounts: %v", err)
+		err = util.WrapError(err, "opening /proc/mounts")
+		glog.Error(err)
 		return err
 	}
 	defer mounts.Close()
@@ -101,7 +103,8 @@ func resizeVolume() error {
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		glog.Errorf("reading /proc/mounts: %v", err)
+		err = util.WrapError(err, "reading /proc/mounts")
+		glog.Error(err.Error())
 		return err
 	}
 	if rootPartition == "" {
@@ -112,7 +115,8 @@ func resizeVolume() error {
 	// Grab the root partition's raw device (e.g. /dev/nvme0n1)
 	out, err := exec.Command("lsblk", "-no", "pkname", rootPartition).Output()
 	if err != nil {
-		glog.Errorf("Could not get the root partition's root block device: %v", err)
+		err = util.WrapError(err, "Could not get the root partition's root block device:")
+		glog.Error(err)
 		return err
 	}
 	rootDevice := "/dev/" + strings.TrimSpace(string(out))
@@ -126,8 +130,14 @@ func resizeVolume() error {
 		}
 		out, err = exec.Command("growpart", rootDevice, partitionNumber).CombinedOutput()
 		if err != nil {
-			glog.Errorf("Could not grow root partition: %v, %s", err, string(out))
-			return err
+			if strings.Contains(string(out), "NOCHANGE") ||
+				strings.Contains(string(out), "cannot be grown") {
+				glog.Warningf("Partition already resized: %s: %s", out, err.Error())
+			} else {
+				err = fmt.Errorf("Could not grow root partition: %v, %s", err, string(out))
+				glog.Error(err)
+				return err
+			}
 		}
 	}
 
@@ -143,11 +153,13 @@ func resizeVolume() error {
 		cmd.Stderr = io.MultiWriter(os.Stderr, &errbuf)
 		glog.Infof("trying to resize %s", rootPartition)
 		if err := cmd.Start(); err != nil {
-			glog.Errorf("resize2fs %s: %v", rootPartition, err)
+			err = util.WrapError(err, "resize2fs %s", rootPartition)
+			glog.Error(err)
 			return err
 		}
 		if err := cmd.Wait(); err != nil {
-			glog.Errorf("resize2fs %s: %v", rootPartition, err)
+			err = util.WrapError(err, "resize2fs %s: stdout: %s stderr: %s", rootPartition, outbuf.String(), errbuf.String())
+			glog.Error(err)
 			return err
 		}
 		if strings.Contains(outbuf.String(), "resizing required") ||


### PR DESCRIPTION
@ldx reported that he was seeing volume resizing errors in his tests and the robinhood environment. This updates the resizing code to report errors and output back to kip so it is logged. It also catches the case where `growpart` fails because the partition is already resized.

I'm unsure why that happens but this should fix that.