### PR TITLE
refactor parsing query parameters in log handler

### DIFF
--- a/pkg/runtime/options.go
+++ b/pkg/runtime/options.go
@@ -1,0 +1,75 @@
+package runtime
+
+import (
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// This is placed in runtime package,
+// because I'll refactor RuntimeService log functions to use this struct.
+type LogOptions struct {
+	UnitName     string
+	Follow       bool
+	WithMetadata bool
+	LineNum      int
+	BytesNum     int
+}
+
+func NewLogOptionsFromURL(logUrl *url.URL) (*LogOptions, error) {
+	var parsedURL *url.URL
+	var err error
+	// If the request came from our
+	// websocket library, the query params are in the path and
+	// r.URL.String() doesn't decode them correctly (they get
+	// escaped).  However, if the request came from a standard web
+	// client (http.Client) the query params are already parsed
+	// out into URL.RawQuery.
+	if logUrl.RawQuery != "" {
+		parsedURL, err = logUrl.Parse(logUrl.String())
+	} else {
+		parsedURL, err = logUrl.Parse(logUrl.Path)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	path := strings.TrimPrefix(parsedURL.Path, "/")
+	parts := strings.Split(path, "/")
+	unit := ""
+	if len(parts) > 3 {
+		unit = strings.Join(parts[3:], "/")
+	}
+	q := parsedURL.Query()
+	followParam := q.Get("follow")
+	follow := false
+	if followParam != "" {
+		follow = true
+	}
+	withMetadata := false
+	if q.Get("metadata") == "1" {
+		withMetadata = true
+	}
+	n := 0
+	numBytes := 0
+	lines := q.Get("lines")
+	strBytes := q.Get("bytes")
+	if lines != "" {
+		if i, err := strconv.Atoi(lines); err == nil {
+			n = i
+		}
+	}
+	if strBytes != "" {
+		if i, err := strconv.Atoi(strBytes); err == nil {
+			numBytes = i
+		}
+	}
+	return &LogOptions{
+		UnitName:     unit,
+		Follow:       follow,
+		WithMetadata: withMetadata,
+		LineNum:      n,
+		BytesNum:     numBytes,
+	}, nil
+}

--- a/pkg/runtime/options_test.go
+++ b/pkg/runtime/options_test.go
@@ -1,0 +1,106 @@
+package runtime
+
+import (
+	"github.com/stretchr/testify/assert"
+	"net/url"
+	"testing"
+)
+
+func TestNewLogOptionsFromURL(t *testing.T) {
+	testCases := []struct {
+		name               string
+		rawUrl             string
+		expectError        bool
+		expectedLogOptions LogOptions
+	}{
+		{
+			name:        "unit name only",
+			rawUrl:      "/rest/v1/logs/unitname",
+			expectError: false,
+			expectedLogOptions: LogOptions{
+				UnitName:     "unitname",
+				Follow:       false,
+				WithMetadata: false,
+				LineNum:      0,
+				BytesNum:     0,
+			},
+		},
+		{
+			name:        "unit, lines and bytes",
+			rawUrl:      "/rest/v1/logs/unitname?lines=10&bytes=5",
+			expectError: false,
+			expectedLogOptions: LogOptions{
+				UnitName:     "unitname",
+				Follow:       false,
+				WithMetadata: false,
+				LineNum:      10,
+				BytesNum:     5,
+			},
+		},
+		{
+			name:        "unit and lines",
+			rawUrl:      "/rest/v1/logs/unitname?lines=10",
+			expectError: false,
+			expectedLogOptions: LogOptions{
+				UnitName:     "unitname",
+				Follow:       false,
+				WithMetadata: false,
+				LineNum:      10,
+				BytesNum:     0,
+			},
+		},
+		{
+			name:        "unit and lines",
+			rawUrl:      "/rest/v1/logs/unitname?bytes=10",
+			expectError: false,
+			expectedLogOptions: LogOptions{
+				UnitName:     "unitname",
+				Follow:       false,
+				WithMetadata: false,
+				LineNum:      0,
+				BytesNum:     10,
+			},
+		},
+		{
+			name:        "follow and metadata",
+			rawUrl:      "/rest/v1/logs/unitname?follow=1&metadata=1",
+			expectError: false,
+			expectedLogOptions: LogOptions{
+				UnitName:     "unitname",
+				Follow:       true,
+				WithMetadata: true,
+				LineNum:      0,
+				BytesNum:     0,
+			},
+		},
+		{
+			name:        "encoded url",
+			rawUrl:      "%2Frest%2Fv1%2Flogs%2Funitname%3Fbytes%3D10%26lines%3D5%26follow%3D1%26metadata%3D1",
+			expectError: false,
+			expectedLogOptions: LogOptions{
+				UnitName:     "unitname",
+				Follow:       true,
+				WithMetadata: true,
+				LineNum:      5,
+				BytesNum:     10,
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			logUrl, err := url.Parse(testCase.rawUrl)
+			assert.NoError(t, err)
+			logOptions, err := NewLogOptionsFromURL(logUrl)
+			if testCase.expectError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.expectedLogOptions.UnitName, logOptions.UnitName)
+			assert.Equal(t, testCase.expectedLogOptions.Follow, logOptions.Follow)
+			assert.Equal(t, testCase.expectedLogOptions.WithMetadata, logOptions.WithMetadata)
+			assert.Equal(t, testCase.expectedLogOptions.LineNum, logOptions.LineNum)
+			assert.Equal(t, testCase.expectedLogOptions.BytesNum, logOptions.BytesNum)
+		})
+	}
+}


### PR DESCRIPTION
This is a first step of refactoring log handler and implementing `logs --follow` with podman runtime.