### PR TITLE
Refactor metrics system to make it pluggable

### DIFF
--- a/pkg/runtime/itzo.go
+++ b/pkg/runtime/itzo.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/elotl/itzo/pkg/api"
 	"github.com/elotl/itzo/pkg/logbuf"
+	"github.com/elotl/itzo/pkg/metrics"
 	itzounit "github.com/elotl/itzo/pkg/unit"
 	"github.com/elotl/itzo/pkg/util"
 	"github.com/golang/glog"
@@ -67,6 +68,8 @@ func (ip *ImagePuller) PullImage(rootdir, name, image string, registryCredential
 }
 
 type ItzoRuntime struct {
+	metrics.ItzoMetricsProvider
+
 	rootdir   string
 	UnitMgr   UnitRunner
 	MountCtl  Mounter

--- a/pkg/runtime/podman.go
+++ b/pkg/runtime/podman.go
@@ -12,6 +12,7 @@ import (
 	"github.com/elotl/itzo/pkg/api"
 	"github.com/elotl/itzo/pkg/convert"
 	"github.com/elotl/itzo/pkg/logbuf"
+	"github.com/elotl/itzo/pkg/metrics"
 	"github.com/golang/glog"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	v1 "k8s.io/api/core/v1"
@@ -40,6 +41,8 @@ var (
 )
 
 type PodmanSandbox struct {
+	metrics.PodmanMetricsProvider
+
 	connText context.Context
 }
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"github.com/elotl/itzo/pkg/api"
 	"github.com/elotl/itzo/pkg/logbuf"
+	"github.com/elotl/itzo/pkg/metrics"
 )
 
 type PodSandbox interface {
@@ -32,10 +33,9 @@ type ContainerService interface {
 // Methods we don't really need are commented out.
 // Having it that similar to CRI opens a door for using it in the future.
 type RuntimeService interface {
-	//Version()
 	PodSandbox
 	ContainerService
-	//UpdateRuntimeConfig()
+	metrics.MetricsProvider
 }
 
 type ImageService interface {

--- a/pkg/server/pod_controller.go
+++ b/pkg/server/pod_controller.go
@@ -507,6 +507,17 @@ func (pc *PodController) useImageOverlayRootfs() bool {
 	return true
 }
 
+// Metrics
+//
+// These methods are just passthrough to the underlying runtime implementation
+func (pc *PodController) ReadSystemMetrics(ifname string) api.ResourceMetrics {
+    return pc.runtime.ReadSystemMetrics(ifname)
+}
+
+func (pc *PodController) ReadUnitMetrics(ifname string) api.ResourceMetrics {
+    return pc.runtime.ReadUnitMetrics(ifname)
+}
+
 // TODO
 func (pc *PodController) GetLogBuffer(unitName string) (*logbuf.LogBuffer, error) {
 	return pc.runtime.GetLogBuffer(unitName)


### PR DESCRIPTION
Create a MetricsProvider interface with the method ReadSystemMetrics and ReadUnitMetrics. This interface must be implemented by runtime.Runtime objects.

The Metrics object has been renamed ItzoMetricsProvider and implements the MetricsProvider interface, and a new  PodmanMetricsProvider has been added. PodmanMetricsProvider isn’t implemented yet.

I kept everything in pkg/metrics/metrics.go for now. Let me know if you’d like me to move it to pkg/runtime/.