### PR TITLE
Enable podman rootless for tests

### DIFF
--- a/pkg/runtime/podman.go
+++ b/pkg/runtime/podman.go
@@ -15,6 +15,7 @@ import (
 	"github.com/golang/glog"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	v1 "k8s.io/api/core/v1"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -313,7 +314,10 @@ func NewPodmanRuntime(rootdir string) (*PodmanRuntime, error) {
 }
 
 func GetPodmanConnection() (context.Context, error) {
-	// Connect to Podman socket
-	connText, err := bindings.NewConnection(context.Background(), PodmanSocketPath)
+	var podmanSocketPath = os.Getenv("PODMAN_SOCKET_PATH")
+	if podmanSocketPath == "" {
+		podmanSocketPath = defaultPodmanSocketPath
+	}
+	connText, err := bindings.NewConnection(context.Background(), podmanSocketPath)
 	return connText, err
 }

--- a/pkg/runtime/podman.go
+++ b/pkg/runtime/podman.go
@@ -21,9 +21,9 @@ import (
 )
 
 const (
-	PodmanSocketPath string = "unix:/run/podman/podman.sock"
-	defaultTimeout   uint   = 30
-	RestartPolicyNo = "no"
+	defaultPodmanSocketPath string = "unix:/run/podman/podman.sock"
+	defaultTimeout          uint   = 30
+	RestartPolicyNo                = "no"
 	// RestartPolicyAlways unconditionally restarts the container.
 	RestartPolicyAlways = "always"
 	// RestartPolicyOnFailure restarts the container on non-0 exit code,
@@ -33,9 +33,9 @@ const (
 
 var (
 	restartPolicyMap = map[api.RestartPolicy]string{
-		api.RestartPolicyAlways: RestartPolicyAlways,
+		api.RestartPolicyAlways:    RestartPolicyAlways,
 		api.RestartPolicyOnFailure: RestartPolicyOnFailure,
-		api.RestartPolicyNever: RestartPolicyNo,
+		api.RestartPolicyNever:     RestartPolicyNo,
 	}
 )
 
@@ -274,7 +274,7 @@ func (p *PodmanRuntime) ReadLogBuffer(unit string, n int) ([]logbuf.LogEntry, er
 		logs = append(logs, logbuf.LogEntry{
 			Timestamp: logLine[0],
 			Source:    logbuf.StdoutLogSource,
-			Line:       line + "\n",
+			Line:      line + "\n",
 		})
 	}
 	return logs, nil

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -28,6 +28,11 @@ make
 $GO_EXECUTABLE test ./...
 
 echo "running podman e2e-tests"
+# Use rootless podman if this script doesn't have root.
+if [ $(id -u) != 0 ]
+then
+    export PODMAN_SOCKET_PATH=unix:/run/user/$(id -u)/podman/podman.sock
+fi
 $GO_EXECUTABLE test ./pkg/server/ -v -args -podman=true
 
 CURRENT_TAG=$(git tag -l --points-at HEAD | head -n 1)


### PR DESCRIPTION
./scripts/run_tests.sh now works without root privileges for podman end to end tests.

There’s a new environment variable to configure the podman socket: PODMAN_SOCKET_PATH.

Set it when starting Itzo to use the alternate socket path:

```shell
env PODMAN_SOCKET_PATH=unix:/run/user/$(id -u)/podman/podman.sock ...
```