### PR TITLE
first check if vm is already created; if so, don't check registry

### DIFF
--- a/pkg/runtime/mac/anka_cli_util.go
+++ b/pkg/runtime/mac/anka_cli_util.go
@@ -62,6 +62,9 @@ func (ac *AnkaCLI) Show(vmID string) (VMShowOutput, error) {
 	if err != nil {
 		return VMShowOutput{}, err
 	}
+	if output.Status != AnkaStatusOK {
+		return VMShowOutput{}, fmt.Errorf("vm %s not found", vmID)
+	}
 	return output, nil
 }
 

--- a/pkg/runtime/mac/mac_test.go
+++ b/pkg/runtime/mac/mac_test.go
@@ -261,7 +261,7 @@ func TestMacRuntime_CreateContainerHappyPath(t *testing.T) {
 	}, &api.PodSpec{}, "", map[string]api.RegistryCredentials{}, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, unitStatus.State.Waiting)
-	assert.Equal(t, "VMTemplatePulled", unitStatus.State.Waiting.Reason)
+	assert.Equal(t, "VMCreated", unitStatus.State.Waiting.Reason)
 	savedVmIdInterface, ok := macRuntime.UnitsVMIDs.Load("dummy")
 	assert.True(t, ok)
 	savedVmId := savedVmIdInterface.(string)


### PR DESCRIPTION
On our poc AMI, vm is already created, so we should first check if vm is already there in stopped state; if so, there is no need for checking vm template existence in registry and pulling it.