### PR TITLE
Fix latest release

### DIFF
--- a/pkg/image/tosi.go
+++ b/pkg/image/tosi.go
@@ -18,8 +18,6 @@ package image
 
 import (
 	"fmt"
-	"github.com/golang/glog"
-
 	"github.com/elotl/itzo/pkg/util"
 )
 
@@ -109,6 +107,5 @@ func (t *Tosi) run(server, image, dest, configPath, username, password string) e
 		t.exe = tp
 	}
 	tosiArgs := t.buildTosiArgs(server, image, dest, configPath, username, password)
-	glog.Infof("executing: %s %v %v %s", tp, TosiOutputLimit, TosiMaxRetries, tosiArgs)
 	return util.RunProg(tp, TosiOutputLimit, TosiMaxRetries, tosiArgs...)
 }

--- a/pkg/runtime/itzo_linux.go
+++ b/pkg/runtime/itzo_linux.go
@@ -32,7 +32,7 @@ type ImagePuller struct {
 }
 
 func (ip *ImagePuller) PullImage(rootdir, name, image string, registryCredentials map[string]api.RegistryCredentials, useOverlayfs bool) error {
-	server, _, err := util.ParseImageSpec(image)
+	server, repo, err := util.ParseImageSpec(image)
 	if err != nil {
 		msg := fmt.Sprintf("Bad image spec for unit %s: %v", name, err)
 		return errors.Wrapf(err, msg)
@@ -53,7 +53,7 @@ func (ip *ImagePuller) PullImage(rootdir, name, image string, registryCredential
 		return errors.Wrapf(err, "opening unit %s for package deploy", name)
 	}
 	u.SetUnitConfigOverlayfs(useOverlayfs)
-	err = u.PullAndExtractImage(image, server, username, password)
+	err = u.PullAndExtractImage(repo, server, username, password)
 	if err != nil {
 		return errors.Wrapf(err, "pulling image %s", image)
 	}

--- a/pkg/runtime/itzo_linux.go
+++ b/pkg/runtime/itzo_linux.go
@@ -32,11 +32,7 @@ type ImagePuller struct {
 }
 
 func (ip *ImagePuller) PullImage(rootdir, name, image string, registryCredentials map[string]api.RegistryCredentials, useOverlayfs bool) error {
-	server, repo, err := util.ParseImageSpec(image)
-	if err != nil {
-		msg := fmt.Sprintf("Bad image spec for unit %s: %v", name, err)
-		return errors.Wrapf(err, msg)
-	}
+	server, repo := util.ParseImageSpec(image)
 	username, password := util.GetRepoCreds(server, registryCredentials)
 
 	if server == "docker.io" {

--- a/pkg/runtime/itzo_linux_test.go
+++ b/pkg/runtime/itzo_linux_test.go
@@ -1,0 +1,51 @@
+package runtime
+
+import (
+	"flag"
+	"github.com/elotl/itzo/pkg/api"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+var tosiIntegration = flag.Bool("tosi-integration", false, "this runs itzo <-> tosi integration tests")
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	ret := m.Run()
+	os.Exit(ret)
+}
+
+func TestImagePuller_PullImagePublicImage(t *testing.T) {
+	if !*tosiIntegration {
+		t.Log("test skipped")
+		return
+	}
+	ip := &ImagePuller{}
+	os.MkdirAll("/tmp/itzo-pull-test", 77)
+	registryCreds := make(map[string]api.RegistryCredentials, 0)
+	err := ip.PullImage("/tmp", "unit-1", "library/hello-world", registryCreds, false)
+	assert.NoError(t, err)
+}
+
+func TestImagePuller_PullImagePrivateImageFromECR(t *testing.T) {
+	if !*tosiIntegration {
+		t.Log("test skipped")
+		return
+	}
+	ip := &ImagePuller{}
+	ecrUser := os.Getenv("TOSI_TEST_DOCKER_USERNAME")
+	ecrPass := os.Getenv("TOSI_TEST_DOCKER_PASS")
+	if ecrUser == "" || ecrPass == "" {
+		t.Fatalf("please set TOSI_TEST_DOCKER_USERNAME & TOSI_TEST_DOCKER_PASS env vars")
+	}
+	os.MkdirAll("/tmp/itzo-pull-test", 0700)
+	registryCreds := make(map[string]api.RegistryCredentials, 0)
+	registryCreds["689494258501.dkr.ecr.us-east-1.amazonaws.com"] = api.RegistryCredentials{
+		Server:   "689494258501.dkr.ecr.us-east-1.amazonaws.com",
+		Username: ecrUser,
+		Password: ecrPass,
+	}
+	err := ip.PullImage("/tmp", "unit-2", "689494258501.dkr.ecr.us-east-1.amazonaws.com/helloserver:latest", registryCreds, false)
+	assert.NoError(t, err)
+}

--- a/pkg/runtime/podman/podman.go
+++ b/pkg/runtime/podman/podman.go
@@ -123,11 +123,7 @@ type PodmanImageService struct {
 }
 
 func (p *PodmanImageService) PullImage(rootdir, name, image string, registryCredentials map[string]api.RegistryCredentials, useOverlayfs bool) error {
-	var server, _, err = util.ParseImageSpec(image)
-	if err != nil {
-		glog.Errorf("error parsing image spec %s: %v", image, err)
-		return err
-	}
+	var server, _ = util.ParseImageSpec(image)
 	exists, err := images.Exists(p.connText, image)
 	if err != nil {
 		glog.Errorf("error checking if image %s already exists: %v", image, err)

--- a/pkg/util/image.go
+++ b/pkg/util/image.go
@@ -26,10 +26,9 @@ import (
 // Example image specs:
 //   ECS: ACCOUNT.dkr.ecr.REGION.amazonaws.com/imagename:tag
 //   Docker Hub: imagename:tag or owner/imagename:tag
-func ParseImageSpec(image string) (string, string, error) {
+func ParseImageSpec(image string) (string, string) {
 	server := ""
 	repo := image
-	var err error
 	parts := strings.Split(image, "/")
 	if len(parts) == 1 {
 		repo = strings.Join([]string{"library", parts[0]}, "/")
@@ -38,7 +37,7 @@ func ParseImageSpec(image string) (string, string, error) {
 		repo = strings.Join(parts[1:], "/")
 	}
 	glog.Infof("image: %s parsed to server: %s repo: %s", image, server, repo)
-	return server, repo, err
+	return server, repo
 }
 
 // Dockerhub can go by several names that the user can specify in

--- a/pkg/util/image.go
+++ b/pkg/util/image.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"github.com/elotl/itzo/pkg/api"
+	"github.com/golang/glog"
 	"strings"
 )
 
@@ -36,6 +37,7 @@ func ParseImageSpec(image string) (string, string, error) {
 		server = parts[0]
 		repo = strings.Join(parts[1:], "/")
 	}
+	glog.Infof("image: %s parsed to server: %s repo: %s", image, server, repo)
 	return server, repo, err
 }
 

--- a/pkg/util/image_test.go
+++ b/pkg/util/image_test.go
@@ -50,3 +50,48 @@ func TestGetRepoCreds(t *testing.T) {
 		assert.Equal(t, tc.p, pass, msg)
 	}
 }
+
+func TestParseImageSpec(t *testing.T)  {
+	cases := []struct{
+		name string
+		imageStr string
+		server string
+		repo string
+		shouldErr bool
+	}{
+		{
+			name: "ecr repo",
+			imageStr: "689494258501.dkr.ecr.us-east-1.amazonaws.com/buildscaler:latest",
+			server: "689494258501.dkr.ecr.us-east-1.amazonaws.com",
+			repo: "buildscaler:latest",
+			shouldErr: false,
+		},
+		{
+			name: "dockerhub with library",
+			imageStr: "library/nginx:stable",
+			server: "",
+			repo: "library/nginx:stable",
+			shouldErr: false,
+		},
+		{
+			name: "dockerhub without library",
+			imageStr: "nginx:stable",
+			server: "",
+			repo: "library/nginx:stable",
+			shouldErr: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server, repo, err := ParseImageSpec(tc.imageStr)
+			if tc.shouldErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.server, server)
+				assert.Equal(t, tc.repo, repo)
+			}
+		})
+	}
+}

--- a/pkg/util/image_test.go
+++ b/pkg/util/image_test.go
@@ -53,66 +53,55 @@ func TestGetRepoCreds(t *testing.T) {
 
 func TestParseImageSpec(t *testing.T) {
 	cases := []struct {
-		name      string
-		imageStr  string
-		server    string
-		repo      string
-		shouldErr bool
+		name     string
+		imageStr string
+		server   string
+		repo     string
 	}{
 		{
-			name:      "ecr repo",
-			imageStr:  "689494258501.dkr.ecr.us-east-1.amazonaws.com/buildscaler:latest",
-			server:    "689494258501.dkr.ecr.us-east-1.amazonaws.com",
-			repo:      "buildscaler:latest",
-			shouldErr: false,
+			name:     "ecr repo",
+			imageStr: "689494258501.dkr.ecr.us-east-1.amazonaws.com/buildscaler:latest",
+			server:   "689494258501.dkr.ecr.us-east-1.amazonaws.com",
+			repo:     "buildscaler:latest",
 		},
 		{
-			name:      "dockerhub with library",
-			imageStr:  "library/nginx:stable",
-			server:    "",
-			repo:      "library/nginx:stable",
-			shouldErr: false,
+			name:     "dockerhub with library",
+			imageStr: "library/nginx:stable",
+			server:   "",
+			repo:     "library/nginx:stable",
 		},
 		{
-			name:      "dockerhub without library",
-			imageStr:  "nginx:stable",
-			server:    "",
-			repo:      "library/nginx:stable",
-			shouldErr: false,
+			name:     "dockerhub without library",
+			imageStr: "nginx:stable",
+			server:   "",
+			repo:     "library/nginx:stable",
 		},
 		{
-			name:      "ecr repo without tag",
-			imageStr:  "689494258501.dkr.ecr.us-east-1.amazonaws.com/buildscaler",
-			server:    "689494258501.dkr.ecr.us-east-1.amazonaws.com",
-			repo:      "buildscaler",
-			shouldErr: false,
+			name:     "ecr repo without tag",
+			imageStr: "689494258501.dkr.ecr.us-east-1.amazonaws.com/buildscaler",
+			server:   "689494258501.dkr.ecr.us-east-1.amazonaws.com",
+			repo:     "buildscaler",
 		},
 		{
-			name:      "dockerhub with library without atg",
-			imageStr:  "library/nginx",
-			server:    "",
-			repo:      "library/nginx",
-			shouldErr: false,
+			name:     "dockerhub with library without atg",
+			imageStr: "library/nginx",
+			server:   "",
+			repo:     "library/nginx",
 		},
 		{
-			name:      "dockerhub without library without tag",
-			imageStr:  "nginx",
-			server:    "",
-			repo:      "library/nginx",
-			shouldErr: false,
+			name:     "dockerhub without library without tag",
+			imageStr: "nginx",
+			server:   "",
+			repo:     "library/nginx",
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			server, repo, err := ParseImageSpec(tc.imageStr)
-			if tc.shouldErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, tc.server, server)
-				assert.Equal(t, tc.repo, repo)
-			}
+			server, repo := ParseImageSpec(tc.imageStr)
+			assert.Equal(t, tc.server, server)
+			assert.Equal(t, tc.repo, repo)
+
 		})
 	}
 }

--- a/pkg/util/image_test.go
+++ b/pkg/util/image_test.go
@@ -23,7 +23,7 @@ func TestGetRepoCreds(t *testing.T) {
 		{
 			server: "",
 			creds: map[string]api.RegistryCredentials{
-				"index.docker.io": api.RegistryCredentials{
+				"index.docker.io": {
 					Username: "myuser",
 					Password: "mypass",
 				},
@@ -34,7 +34,7 @@ func TestGetRepoCreds(t *testing.T) {
 		{
 			server: "docker.io",
 			creds: map[string]api.RegistryCredentials{
-				"registry-1.docker.io": api.RegistryCredentials{
+				"registry-1.docker.io": {
 					Username: "myuser",
 					Password: "mypass",
 				},
@@ -51,33 +51,54 @@ func TestGetRepoCreds(t *testing.T) {
 	}
 }
 
-func TestParseImageSpec(t *testing.T)  {
-	cases := []struct{
-		name string
-		imageStr string
-		server string
-		repo string
+func TestParseImageSpec(t *testing.T) {
+	cases := []struct {
+		name      string
+		imageStr  string
+		server    string
+		repo      string
 		shouldErr bool
 	}{
 		{
-			name: "ecr repo",
-			imageStr: "689494258501.dkr.ecr.us-east-1.amazonaws.com/buildscaler:latest",
-			server: "689494258501.dkr.ecr.us-east-1.amazonaws.com",
-			repo: "buildscaler:latest",
+			name:      "ecr repo",
+			imageStr:  "689494258501.dkr.ecr.us-east-1.amazonaws.com/buildscaler:latest",
+			server:    "689494258501.dkr.ecr.us-east-1.amazonaws.com",
+			repo:      "buildscaler:latest",
 			shouldErr: false,
 		},
 		{
-			name: "dockerhub with library",
-			imageStr: "library/nginx:stable",
-			server: "",
-			repo: "library/nginx:stable",
+			name:      "dockerhub with library",
+			imageStr:  "library/nginx:stable",
+			server:    "",
+			repo:      "library/nginx:stable",
 			shouldErr: false,
 		},
 		{
-			name: "dockerhub without library",
-			imageStr: "nginx:stable",
-			server: "",
-			repo: "library/nginx:stable",
+			name:      "dockerhub without library",
+			imageStr:  "nginx:stable",
+			server:    "",
+			repo:      "library/nginx:stable",
+			shouldErr: false,
+		},
+		{
+			name:      "ecr repo without tag",
+			imageStr:  "689494258501.dkr.ecr.us-east-1.amazonaws.com/buildscaler",
+			server:    "689494258501.dkr.ecr.us-east-1.amazonaws.com",
+			repo:      "buildscaler",
+			shouldErr: false,
+		},
+		{
+			name:      "dockerhub with library without atg",
+			imageStr:  "library/nginx",
+			server:    "",
+			repo:      "library/nginx",
+			shouldErr: false,
+		},
+		{
+			name:      "dockerhub without library without tag",
+			imageStr:  "nginx",
+			server:    "",
+			repo:      "library/nginx",
 			shouldErr: false,
 		},
 	}

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -26,6 +26,11 @@ GO_EXECUTABLE=$(which go || true)
 cd $ROOT_DIR
 make
 $GO_EXECUTABLE test ./...
+echo "running itzo tosi integration tests"
+export TOSI_TEST_DOCKER_USERNAME=AWS
+export TOSI_TEST_DOCKER_PASS=$(aws ecr get-login --no-include-email --region us-east-1 | awk '{print $6}')
+$GO_EXECUTABLE test ./pkg/runtime -v -args -tosi-integration
+
 export PODMAN_SOCKET_PATH=unix:/run/podman/podman.sock
 echo "running podman e2e-tests"
 # Use rootless podman if this script doesn't have root.


### PR DESCRIPTION
This fixes regression introduced in `v1.2.0` and adds test for itzo <-> tosi integration, so we shouldn't have such situation in the future.

The issue was caused by passing server url and full image string (e.g. `<docker-registry>/repo/image:tag`) as repo:tag to the `u.PullAndExtractImage` method, which resulted in wrong final url (server url was duplicated).

Thanks @jrroman for reporting this one :+1: 